### PR TITLE
1.5.4

### DIFF
--- a/classes/class-dibs-ajax-calls.php
+++ b/classes/class-dibs-ajax-calls.php
@@ -256,7 +256,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 	 */
 	public static function ajax_on_checkout_error() {
 
-		/*
+		
 		$order_id        = WC()->session->get( 'dibs_incomplete_order' );
 		$order           = wc_get_order( $order_id );
 		$dibs_order_data = WC()->session->get( 'dibs_order_data' );
@@ -296,8 +296,8 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 		// Save order totals
 		$order->calculate_totals();
 		$order->save();
-		*/
-
+		
+		/*
 		$create_order = new DIBS_Create_Local_Order_Fallback();
 		// Create the order.
 		$order    = $create_order->create_order();
@@ -334,7 +334,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 
 		// Update the DIBS Order with the Order ID
 		$create_order->update_order_reference_in_dibs( $order->get_order_number() );
-
+		
 		// Add order note
 		if ( ! empty( $_POST['error_message'] ) ) { // Input var okay.
 			$error_message = 'Error message: ' . sanitize_text_field( trim( $_POST['error_message'] ) );
@@ -343,7 +343,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 		}
 		$note = sprintf( __( 'This order was made as a fallback due to an error in the checkout (%s). Please verify the order with DIBS.', 'dibs-easy-for-woocommerce' ), $error_message );
 		$order->add_order_note( $note );
-
+		*/
 		$redirect_url = wc_get_endpoint_url( 'order-received', '', wc_get_page_permalink( 'checkout' ) );
 		$redirect_url = add_query_arg(
 			array(

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -55,7 +55,7 @@ class DIBS_Post_Checkout {
 					}
 				} elseif ( array_key_exists( 'code', $request ) && '1001' == $request->code ) { // Response with error code for overcharged order
 					$message = 'Payment overcharged';
-					$this->charge_failed( $wc_order, false, $message );
+					$this->charge_failed( $wc_order, false, $request->message );
 				} else {
 					$this->charge_failed( $wc_order );
 				}
@@ -82,13 +82,13 @@ class DIBS_Post_Checkout {
 			// $request = $request->make_request( 'POST', $body, $endpoint_suffix );
 			$request = new DIBS_Requests_Cancel_Order( $order_id );
 			$request = json_decode( $request->request() );
-
+			
 			$wc_order = wc_get_order( $order_id );
 
 			if ( null === $request ) {
 				$wc_order->add_order_note( sprintf( __( 'Order has been canceled in DIBS', 'dibs-easy-for-woocommerce' ) ) );
 			} else {
-				$wc_order->add_order_note( sprintf( __( 'There was a problem canceling the order in DIBS', 'dibs-easy-for-woocommerce' ) ) );
+				$wc_order->add_order_note( sprintf( __( 'There was a problem canceling the order in DIBS: %s', 'dibs-easy-for-woocommerce' ), $request->message ) );
 			}
 		}
 	}

--- a/classes/requests/class-dibs-requests-activate-order.php
+++ b/classes/requests/class-dibs-requests-activate-order.php
@@ -28,7 +28,8 @@ class DIBS_Requests_Activate_Order extends DIBS_Requests2 {
 			return wp_remote_retrieve_body( $response );
 		} else {
 			$this->get_error_message( $response );
-			return 'ERROR';
+			return wp_remote_retrieve_body( $response );
+			//return 'ERROR';
 		}
 	}
 

--- a/classes/requests/class-dibs-requests-cancel-order.php
+++ b/classes/requests/class-dibs-requests-cancel-order.php
@@ -28,7 +28,8 @@ class DIBS_Requests_Cancel_Order extends DIBS_Requests2 {
 			return wp_remote_retrieve_body( $response );
 		} else {
 			$this->get_error_message( $response );
-			return 'ERROR';
+			return wp_remote_retrieve_body( $response );
+			//return 'ERROR';
 		}
 	}
 

--- a/classes/requests/class-dibs-requests-create-dibs-order.php
+++ b/classes/requests/class-dibs-requests-create-dibs-order.php
@@ -13,15 +13,15 @@ class DIBS_Requests_Create_DIBS_Order extends DIBS_Requests2 {
 
 		$response = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $response ) ) {
-			$this->get_error_message( $response );
-			return 'ERROR';
+			return $this->get_error_message( $response );
+			//return 'ERROR';
 		}
 
 		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
 			return wp_remote_retrieve_body( $response );
 		} else {
-			$this->get_error_message( $response );
-			return wp_remote_retrieve_body( $response );
+			return json_encode( $this->get_error_message( $response ) );
+			//return wp_remote_retrieve_body( $response );
 		}
 	}
 

--- a/classes/requests/class-dibs-requests-get-dibs-order.php
+++ b/classes/requests/class-dibs-requests-get-dibs-order.php
@@ -15,6 +15,9 @@ class DIBS_Requests_Get_DIBS_Order extends DIBS_Requests2 {
 		$request_url = $this->endpoint . 'payments/' . $this->payment_id;
 
 		$response = wp_remote_request( $request_url, $this->get_request_args() );
+
+		DIBS_Easy::log( 'DIBS GET Order response (' . $request_url . '): ' . stripslashes_deep( json_encode( $response ) ) );
+
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
 			return 'ERROR';

--- a/classes/requests/class-dibs-requests-update-dibs-order-reference.php
+++ b/classes/requests/class-dibs-requests-update-dibs-order-reference.php
@@ -10,8 +10,8 @@ class DIBS_Requests_Update_DIBS_Order_Reference extends DIBS_Requests2 {
 	public function __construct( $payment_id, $order_id ) {
 		$this->payment_id 	= $payment_id;
 		$this->order_id   	= $order_id;
-		$order 				= wc_get_order( $order_id );
-		$this->order_number = $order->get_order_number();
+		
+		$this->order_number = $this->get_order_number( $order_id );
 
 		parent::__construct();
 	}
@@ -49,5 +49,26 @@ class DIBS_Requests_Update_DIBS_Order_Reference extends DIBS_Requests2 {
 			'reference'   => $this->order_number,
 			'checkoutUrl' => wc_get_checkout_url(),
 		);
+	}
+
+	public function get_order_number( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if( is_object( $order ) ) {
+			// Make sure to run Sequential Order numbers if plugin exsists
+			if ( class_exists( 'WC_Seq_Order_Number_Pro' ) ) {
+				$sequential = new WC_Seq_Order_Number_Pro;
+				$sequential->set_sequential_order_number( $order_id );
+				$reference = $sequential->get_order_number( $order->get_order_number(), $order );
+			} elseif ( class_exists( 'WC_Seq_Order_Number' ) ) {
+				$sequential = new WC_Seq_Order_Number;
+				$sequential->set_sequential_order_number( $order_id, get_post( $order_id ) );
+				$reference = $sequential->get_order_number( $order->get_order_number(), $order );
+			} else {
+				$reference = $order->get_order_number();
+			}
+		} else {
+			$reference = $order_id;
+		}
+		return $reference;
 	}
 }

--- a/classes/requests/class-dibs-requests.php
+++ b/classes/requests/class-dibs-requests.php
@@ -27,8 +27,12 @@ class DIBS_Requests2 {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-
+		
 		$response_body = wp_remote_retrieve_body( $response );
+		if( empty( $response_body ) ) {
+			$response_body = 'Response code ' . $response['response']['code'] . '. Message: ' . $response['response']['message'];
+		}
+
 		$errors        = new WP_Error();
 		$errors->add( 'dibs_easy', $response_body );
 		

--- a/classes/requests/helpers/class-dibs-requests-get-items.php
+++ b/classes/requests/helpers/class-dibs-requests-get-items.php
@@ -21,7 +21,10 @@ class DIBS_Requests_Items {
 
 		// Get cart shipping
 		if ( WC()->cart->needs_shipping() ) {
-			$items[] = self::get_shipping();
+			$shipping = self::get_shipping();
+			if ( null !== $shipping ) {
+				$items[] = $shipping;
+			}
 		}
 
 		return $items;
@@ -35,7 +38,7 @@ class DIBS_Requests_Items {
 			$product    = wc_get_product( $cart_item['product_id'] );
 			$product_id = $cart_item['product_id'];
 		}
-		
+
 		return array(
 			'reference'        => self::get_sku( $product, $product_id ),
 			'name'             => wc_dibs_clean_name( $product->get_title() ),

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_VERSION', '1.5.3' );
+define( 'WC_DIBS_EASY_VERSION', '1.5.3' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );
@@ -147,7 +147,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 				}
 
 				wp_enqueue_script( 'dibs-script', $script_url, array( 'jquery' ) );
-				wp_register_script( 'checkout', plugins_url( '/assets/js/checkout.js', __FILE__ ), array( 'jquery' ), WC_DIBS_VERSION );
+				wp_register_script( 'checkout', plugins_url( '/assets/js/checkout.js', __FILE__ ), array( 'jquery' ), WC_DIBS_EASY_VERSION );
 				wp_localize_script(
 					'checkout', 'wc_dibs_easy', array(
 						'dibs_payment_id'                  => $dibs_payment_id,
@@ -169,7 +169,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 					'dibs_style',
 					plugins_url( '/assets/css/style.css', __FILE__ ),
 					array(),
-					WC_DIBS_VERSION
+					WC_DIBS_EASY_VERSION
 				);
 				wp_enqueue_style( 'dibs_style' );
 			}

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             DIBS Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
- * Version:                 1.5.3
+ * Version:                 1.5.4
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.5.3' );
+define( 'WC_DIBS_EASY_VERSION', '1.5.4' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/includes/dibs-checkout-functions.php
+++ b/includes/dibs-checkout-functions.php
@@ -201,7 +201,7 @@ function wc_dibs_get_private_key() {
 }
 
 function wc_dibs_clean_name( $name ) {
-	$name = preg_replace( '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9åäöüÅÄÖÜ\s]+/i', '', $name );
+	$name = preg_replace( '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9åäöüÅÄÖÜØÆøæ\s]+/i', '', $name );
 
 	return $name;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -56,9 +56,14 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
-= 2018.10.xx    - version 1.5.4 =
+= 2018.10.29    - version 1.5.4 =
 * Tweak			- Improved messaging and handling of order status if order activate & cancel request was denied from DIBS.
+* Tweak			- Change plugin version constant name to WC_DIBS_EASY_VERSION (conflicted with D2 plugin).
+* Tweak			- Add get_order_number function and check for Sequential order numbers plugin features.
+* Fix			- Improved error message handling in communication with DIBS.
 * Fix			- Don't try to send shipping item row if no shipping is available. Caused Easy Checkout not to be rendered.
+* Fix			- Extended wc_dibs_clean_name to allow ØÆøæ. Caused Easy Checkout not to be rendered.
+* Fix			- Revert ajax_on_checkout_error function to better handle order completion when regular Woo checkout submission fails.
 
 = 2018.10.23    - version 1.5.3 =
 * Fix			- Fixed issue where first shipping method always was set as order shipping in some stores.

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,10 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2018.10.xx    - version 1.5.4 =
+* Tweak			- Improved messaging and handling of order status if order activate & cancel request was denied from DIBS.
+* Fix			- Don't try to send shipping item row if no shipping is available. Caused Easy Checkout not to be rendered.
+
 = 2018.10.23    - version 1.5.3 =
 * Fix			- Fixed issue where first shipping method always was set as order shipping in some stores.
 


### PR DESCRIPTION
* Tweak - Improved messaging and handling of order status if order activate & cancel request was denied from DIBS.
* Tweak - Change plugin version constant name to WC_DIBS_EASY_VERSION (conflicted with D2 plugin).
* Tweak - Add get_order_number function and check for Sequential order numbers plugin features.
* Fix - Improved error message handling in communication with DIBS.
* Fix	- Don't try to send shipping item row if no shipping is available. Caused Easy Checkout not to be rendered.
* Fix	- Extended wc_dibs_clean_name to allow ØÆøæ. Caused Easy Checkout not to be rendered.
* Fix	- Revert ajax_on_checkout_error function to better handle order completion when regular Woo checkout submission fails.