### PR TITLE
Add subscriptions support + improvements

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -42,12 +42,26 @@
                                 $( '#shipping_country' ).val( response.responseJSON.data.country );
                                 $( 'input#billing_postcode' ).val( response.responseJSON.data.postCode );
                                 $( 'input#shipping_postcode' ).val( response.responseJSON.data.postCode )
-                                $(document.body).trigger('update_checkout'); 
+                            }
+                            
+                            if( 'yes' == response.responseJSON.data.mustLogin ) {
+                                // Customer might need to login. Inform customer and freeze DIBS checkout.
+                                var $form = $( 'form.checkout' );
+                                $form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-updateOrderReview"><ul class="woocommerce-error" role="alert"><li>' + response.responseJSON.data.mustLoginMessage + '</li></ul></div>' );
+                                dibsCheckout.freezeCheckout();
+                                
+                                var etop = $('form.checkout').offset().top;
+                                $('html, body').animate({
+                                    scrollTop: etop
+                                  }, 1000);
+                            } else {
+                                // All good release checkout and trigger update_checkout event
+                                dibsCheckout.thawCheckout();
+                                $(document.body).trigger('update_checkout');
                             }
                         }
                     }
                 );
-                dibsCheckout.thawCheckout();
             }
         });
     }

--- a/classes/class-dibs-easy-gateway.php
+++ b/classes/class-dibs-easy-gateway.php
@@ -28,8 +28,8 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 			'products',
 			'refunds',
 			'subscriptions',
-			'subscription_cancellation', 
-			'subscription_suspension', 
+			'subscription_cancellation',
+			'subscription_suspension',
 			'subscription_reactivation',
 			'subscription_amount_changes',
 			'subscription_date_changes',
@@ -152,8 +152,8 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 		$order = wc_get_order( $order_id );
 
 		$payment_id = get_post_meta( $order_id, '_dibs_payment_id', true );
-		$request = new DIBS_Requests_Update_DIBS_Order_Reference( $payment_id, $order_id );
-		$request = $request->request();
+		$request    = new DIBS_Requests_Update_DIBS_Order_Reference( $payment_id, $order_id );
+		$request    = $request->request();
 
 		$request = new DIBS_Requests_Get_DIBS_Order( $payment_id );
 		$request = $request->request();
@@ -162,11 +162,11 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 			do_action( 'dibs_easy_process_payment', $order_id, $request );
 
 			update_post_meta( $order_id, 'dibs_payment_type', $request->payment->paymentDetails->paymentType );
-			
-			if('CARD' == $request->payment->paymentDetails->paymentType ) {
+
+			if ( 'CARD' == $request->payment->paymentDetails->paymentType ) {
 				update_post_meta( $order_id, 'dibs_customer_card', $request->payment->paymentDetails->cardDetails->maskedPan );
 			}
-			
+
 			$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
 			$order->payment_complete( $payment_id );
 		}
@@ -186,10 +186,9 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 		$request               = new DIBS_Requests_Get_DIBS_Order( $payment_id );
 		$this->checkout_fields = $request->request();
 
-		//$order_id = WC()->session->get( 'dibs_incomplete_order' );
-
+		// $order_id = WC()->session->get( 'dibs_incomplete_order' );
 		// Check payment status
-		if ( key_exists( 'reservedAmount', $this->checkout_fields->payment->summary )  || key_exists( 'id', $this->checkout_fields->payment->subscription ) ) {
+		if ( key_exists( 'reservedAmount', $this->checkout_fields->payment->summary ) || key_exists( 'id', $this->checkout_fields->payment->subscription ) ) {
 			// Payment is ok, DIBS have reserved an amount
 			// Convert country code from 3 to 2 letters
 			if ( $this->checkout_fields->payment->consumer->shippingAddress->country ) {
@@ -205,14 +204,18 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 			// Redirect the customer to checkout page but change the param paymentId to dibs-payment-id.
 			// By doing this the WC form will not be submitted, instead the Easy iframe will be displayed again.
 			// @todo - log this event in DIBS log
-
 			$redirect_url = add_query_arg( 'dibs-payment-id', $payment_id, trailingslashit( wc_get_checkout_url() ) );
 			wp_redirect( $redirect_url );
 			exit;
 		}
 	}
 
-	// Helper function to prepare the cart session before processing the order form
+	/**
+	 * Helper function to prepare the cart session before processing the order form
+	 *
+	 * @param string|boolean $country Country returned from DIBS.
+	 * @return void
+	 */
 	public function prepare_cart_before_form_processing( $country = false ) {
 		if ( $country ) {
 			WC()->customer->set_billing_country( $country );

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -71,10 +71,7 @@ class DIBS_Subscriptions {
 				$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', $customer_id ) );
 				$order->save();
 			}
-			error_log( $order_id . ' wcs_order_contains_subscription' );
-
 		} else {
-			error_log( $order_id . ' DDOES NOT wcs_order_contains_subscription' );
 		}
 	}
 
@@ -191,8 +188,7 @@ class DIBS_Subscriptions {
 
 		$recurring_orders = new DIBS_Request_Get_Subscription_Bulk_Id( $subscription_bulk_id );
 		$recurring_orders = $recurring_orders->request();
-		error_log( '$recurring_orders in check_subscription_status ' . var_export( $recurring_order_status, true ) );
-		$payment_id = null;
+		$payment_id       = null;
 		foreach ( $recurring_orders->page as $recurring_order ) {
 			if ( $recurring_order->subscriptionId == $recurring_token ) {
 				$payment_id = $recurring_order->paymentId;

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -19,24 +19,23 @@ class DIBS_Subscriptions {
 	public function __construct() {
 		add_filter( 'dibs_easy_create_order_args', array( $this, 'maybe_add_subscription' ), 9, 1 );
 		add_action( 'dibs_easy_process_payment', array( $this, 'set_recurring_token_for_order' ), 10, 2 );
-		
+
 		add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'show_recurring_token' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'save_dibs_recurring_token_update' ), 45, 2 );
 
 		// Maybe create user
 		// @todo - keep working on this or remove it when we get the new order submission flow.
-		//add_action( 'dibs_prepare_local_order_before_form_processing', array( $this, 'maybe_assign_or_create_user' ) );
-		//add_action( 'dibs_easy_process_payment', array( $this, 'maybe_assign_or_create_user' ) );
-		
+		// add_action( 'dibs_prepare_local_order_before_form_processing', array( $this, 'maybe_assign_or_create_user' ) );
+		// add_action( 'dibs_easy_process_payment', array( $this, 'maybe_assign_or_create_user' ) );
 		// Charge renewal payment
 		add_action( 'woocommerce_scheduled_subscription_payment_dibs_easy', array( $this, 'trigger_scheduled_payment' ), 10, 2 );
 
 		add_action( 'wc_dibs_easy_check_subscription_status', array( $this, 'check_subscription_status' ), 10, 2 );
-		
+
 	}
 
-	
-	
+
+
 	/**
 	 * Assigns an order to a user. Needed for Subscriptions.
 	 *
@@ -48,18 +47,17 @@ class DIBS_Subscriptions {
 		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order_id ) ) {
 			$order = wc_get_order( $order_id );
 
-			if( email_exists( $order->get_billing_email() ) ) {
+			if ( email_exists( $order->get_billing_email() ) ) {
 				// Email exist in WP
-				if( !$order->get_customer_id() ) {
+				if ( ! $order->get_customer_id() ) {
 					// No customer was assigned to the order - let's set it now.
-					$user = get_user_by( 'email', $order->get_billing_email() );
+					$user        = get_user_by( 'email', $order->get_billing_email() );
 					$customer_id = $user->ID;
 					$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', $customer_id ) );
 					$order->save();
 				}
 			} else {
 				// Email does not exist - lets create the customer
-
 				// Generate username - force create user name even if get_option( 'woocommerce_registration_generate_username' ) is set to no.
 				$username = sanitize_user( current( explode( '@', $order->get_billing_email() ) ), true );
 				// Ensure username is unique.
@@ -73,10 +71,10 @@ class DIBS_Subscriptions {
 				$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', $customer_id ) );
 				$order->save();
 			}
-			error_log( $order_id . ' wcs_order_contains_subscription');
+			error_log( $order_id . ' wcs_order_contains_subscription' );
 
 		} else {
-			error_log( $order_id . ' DDOES NOT wcs_order_contains_subscription');
+			error_log( $order_id . ' DDOES NOT wcs_order_contains_subscription' );
 		}
 	}
 
@@ -90,8 +88,8 @@ class DIBS_Subscriptions {
 		// Check if we have a subscription product. If yes set recurring field.
 		if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
 			$request_args['subscription'] = array(
-				'endDate'	=> date( 'Y-m-d\TH:i', strtotime( '+150 year' ) ),
-				'interval'	=> 0,
+				'endDate'  => date( 'Y-m-d\TH:i', strtotime( '+150 year' ) ),
+				'interval' => 0,
 			);
 		}
 		return $request_args;
@@ -104,17 +102,17 @@ class DIBS_Subscriptions {
 	 */
 	public function set_recurring_token_for_order( $order_id, $dibs_order ) {
 		$wc_order = wc_get_order( $order_id );
-		if( isset( $dibs_order->payment->subscription->id ) ) {
+		if ( isset( $dibs_order->payment->subscription->id ) ) {
 			update_post_meta( $order_id, '_dibs_recurring_token', $dibs_order->payment->subscription->id );
-			
+
 			$dibs_subscription = new DIBS_Requests_Get_Subscription( $dibs_order->payment->subscription->id );
-			$request = $dibs_subscription->request();
-			if('CARD' == $request->paymentDetails->paymentType ) {
+			$request           = $dibs_subscription->request();
+			if ( 'CARD' == $request->paymentDetails->paymentType ) {
 				update_post_meta( $order_id, 'dibs_payment_type', $request->paymentDetails->paymentType );
 				update_post_meta( $order_id, 'dibs_customer_card', $request->paymentDetails->cardDetails->maskedPan );
 			}
 
-			// This function is run after WCS has created the subscription order. 
+			// This function is run after WCS has created the subscription order.
 			// Let's add the _dibs_recurring_token to the subscription as well.
 			if ( class_exists( 'WC_Subscription' ) && wcs_order_contains_subscription( $wc_order ) ) {
 				$subcriptions = wcs_get_subscriptions_for_order( $order_id );
@@ -135,7 +133,7 @@ class DIBS_Subscriptions {
 	 */
 	public function trigger_scheduled_payment( $renewal_total, $renewal_order ) {
 		$order_id = $renewal_order->get_id();
-		
+
 		// Get recurring token
 		$recurring_token = get_post_meta( $order_id, '_dibs_recurring_token', true );
 		if ( empty( $recurring_token ) ) {
@@ -146,25 +144,24 @@ class DIBS_Subscriptions {
 		$create_order_response = new DIBS_Request_Charge_Subscription( $order_id );
 		$create_order_response = $create_order_response->request();
 
-		if ( !empty( $create_order_response->bulkId ) ) {
+		if ( ! empty( $create_order_response->bulkId ) ) {
 			// We got a bulkId in response. Save it in the renewal order and make a new request to DIBS to get the status and ID of the transaction
 			update_post_meta( $order_id, '_dibs_recurring_bulk_id', $create_order_response->bulkId );
 
 			$recurring_orders = new DIBS_Request_Get_Subscription_Bulk_Id( $create_order_response->bulkId );
 			$recurring_orders = $recurring_orders->request();
-			
+
 			$payment_id = null;
-			foreach( $recurring_orders->page as $recurring_order ) {
-				if( $recurring_order->subscriptionId == $recurring_token ) {
+			foreach ( $recurring_orders->page as $recurring_order ) {
+				if ( $recurring_order->subscriptionId == $recurring_token ) {
 					$payment_id = $recurring_order->paymentId;
 					break;
 				}
 			}
 
-			if ( !empty( $payment_id ) ) {
-			
-				
-				if( 'Succeeded' == $recurring_order->status ) {
+			if ( ! empty( $payment_id ) ) {
+
+				if ( 'Succeeded' == $recurring_order->status ) {
 					WC_Subscriptions_Manager::process_subscription_payments_on_order( $renewal_order );
 					$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
 					$renewal_order->payment_complete( $payment_id );
@@ -172,16 +169,13 @@ class DIBS_Subscriptions {
 					$renewal_order->add_order_note( sprintf( __( 'Payment status not available: Scheduling payment status check to be triggered in 1 minute.', 'dibs-easy-for-woocommerce' ), $payment_id ) );
 					wp_schedule_single_event( time() + 60, 'wc_dibs_easy_check_subscription_status', array( $order_id, $create_order_response->bulkId ) );
 				}
-				
 			} else {
 				WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $renewal_order );
 				$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS. Error code: %1$s. Message: %2$s', 'dibs-easy-for-woocommerce' ), 'fel', $create_order_response->bulkId ) );
 			}
 		}
-		
-		
-		
-		//error_log('$create_order_response ' . var_export($create_order_response, true));
+
+		// error_log('$create_order_response ' . var_export($create_order_response, true));
 	}
 
 	/**
@@ -191,25 +185,24 @@ class DIBS_Subscriptions {
 	 * @param object $renewal_order The WooCommerce order for the renewal.
 	 */
 	public function check_subscription_status( $order_id, $subscription_bulk_id ) {
-		$order 				= wc_get_order( $order_id );
-		//$payment_id 		= $order->get_transaction_id();
-		$recurring_token 	= get_post_meta( $order_id, '_dibs_recurring_token', true );
-		
+		$order = wc_get_order( $order_id );
+		// $payment_id       = $order->get_transaction_id();
+		$recurring_token = get_post_meta( $order_id, '_dibs_recurring_token', true );
+
 		$recurring_orders = new DIBS_Request_Get_Subscription_Bulk_Id( $subscription_bulk_id );
 		$recurring_orders = $recurring_orders->request();
-		error_log('$recurring_orders in check_subscription_status ' . var_export($recurring_order_status, true));
+		error_log( '$recurring_orders in check_subscription_status ' . var_export( $recurring_order_status, true ) );
 		$payment_id = null;
-		foreach( $recurring_orders->page as $recurring_order ) {
-			if( $recurring_order->subscriptionId == $recurring_token ) {
+		foreach ( $recurring_orders->page as $recurring_order ) {
+			if ( $recurring_order->subscriptionId == $recurring_token ) {
 				$payment_id = $recurring_order->paymentId;
 				break;
 			}
 		}
 
-		if ( !empty( $payment_id ) ) {
-		
-			
-			if( 'Succeeded' == $recurring_order->status ) {
+		if ( ! empty( $payment_id ) ) {
+
+			if ( 'Succeeded' == $recurring_order->status ) {
 				WC_Subscriptions_Manager::process_subscription_payments_on_order( $order );
 				$order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
 				$order->payment_complete( $payment_id );
@@ -217,7 +210,6 @@ class DIBS_Subscriptions {
 				$order->add_order_note( sprintf( __( 'Payment status not correct for subscription. Status: %s', 'dibs-easy-for-woocommerce' ), $recurring_order->status ) );
 				WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $order );
 			}
-			
 		} else {
 			$order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS during scheduled request. No paymentId found in response', 'dibs-easy-for-woocommerce' ), 'fel' ) );
 		}
@@ -250,7 +242,7 @@ class DIBS_Subscriptions {
 
 	public function save_dibs_recurring_token_update( $post_id, $post ) {
 		$order = wc_get_order( $post_id );
-		if ( wcs_order_contains_subscription( $order ) && get_post_meta( $post_id, '_dibs_recurring_token' ) ) {
+		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && get_post_meta( $post_id, '_dibs_recurring_token' ) ) {
 			update_post_meta( $post_id, '_dibs_recurring_token', wc_clean( $_POST['_dibs_recurring_token'] ) );
 		}
 

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -1,0 +1,259 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Handles subscription payments with Klarna checkout.
+ *
+ * @class    DIBS_Subscriptions
+ * @version  1.0
+ * @package  DIBS/Classes
+ * @category Class
+ * @author   Krokedil
+ */
+class DIBS_Subscriptions {
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_filter( 'dibs_easy_create_order_args', array( $this, 'maybe_add_subscription' ), 9, 1 );
+		add_action( 'dibs_easy_process_payment', array( $this, 'set_recurring_token_for_order' ), 10, 2 );
+		
+		add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'show_recurring_token' ) );
+		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'save_dibs_recurring_token_update' ), 45, 2 );
+
+		// Maybe create user
+		// @todo - keep working on this or remove it when we get the new order submission flow.
+		//add_action( 'dibs_prepare_local_order_before_form_processing', array( $this, 'maybe_assign_or_create_user' ) );
+		//add_action( 'dibs_easy_process_payment', array( $this, 'maybe_assign_or_create_user' ) );
+		
+		// Charge renewal payment
+		add_action( 'woocommerce_scheduled_subscription_payment_dibs_easy', array( $this, 'trigger_scheduled_payment' ), 10, 2 );
+
+		add_action( 'wc_dibs_easy_check_subscription_status', array( $this, 'check_subscription_status' ), 10, 2 );
+		
+	}
+
+	
+	
+	/**
+	 * Assigns an order to a user. Needed for Subscriptions.
+	 *
+	 * @param array $order_id The WooCommerce order ID.
+	 * @return array
+	 */
+	public function maybe_assign_or_create_user( $order_id ) {
+		// Check if we have a subscription product. If yes set check if we need to assign or create customer to order.
+		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order_id ) ) {
+			$order = wc_get_order( $order_id );
+
+			if( email_exists( $order->get_billing_email() ) ) {
+				// Email exist in WP
+				if( !$order->get_customer_id() ) {
+					// No customer was assigned to the order - let's set it now.
+					$user = get_user_by( 'email', $order->get_billing_email() );
+					$customer_id = $user->ID;
+					$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', $customer_id ) );
+					$order->save();
+				}
+			} else {
+				// Email does not exist - lets create the customer
+
+				// Generate username - force create user name even if get_option( 'woocommerce_registration_generate_username' ) is set to no.
+				$username = sanitize_user( current( explode( '@', $order->get_billing_email() ) ), true );
+				// Ensure username is unique.
+				$append     = 1;
+				$o_username = $username;
+				while ( username_exists( $username ) ) {
+					$username = $o_username . $append;
+					$append++;
+				}
+				$customer_id = wc_create_new_customer( $order->get_billing_email(), $username, wp_generate_password() );
+				$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', $customer_id ) );
+				$order->save();
+			}
+			error_log( $order_id . ' wcs_order_contains_subscription');
+
+		} else {
+			error_log( $order_id . ' DDOES NOT wcs_order_contains_subscription');
+		}
+	}
+
+	/**
+	 * Marks the order as a recurring order for Klarna
+	 *
+	 * @param array $request_args The Klarna request arguments.
+	 * @return array
+	 */
+	public function maybe_add_subscription( $request_args ) {
+		// Check if we have a subscription product. If yes set recurring field.
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			$request_args['subscription'] = array(
+				'endDate'	=> date( 'Y-m-d\TH:i', strtotime( '+150 year' ) ),
+				'interval'	=> 0,
+			);
+		}
+		return $request_args;
+	}
+
+	/**
+	 * Sets the recurring token for the subscription order
+	 *
+	 * @return void
+	 */
+	public function set_recurring_token_for_order( $order_id, $dibs_order ) {
+		$wc_order = wc_get_order( $order_id );
+		if( isset( $dibs_order->payment->subscription->id ) ) {
+			update_post_meta( $order_id, '_dibs_recurring_token', $dibs_order->payment->subscription->id );
+			
+			$dibs_subscription = new DIBS_Requests_Get_Subscription( $dibs_order->payment->subscription->id );
+			$request = $dibs_subscription->request();
+			if('CARD' == $request->paymentDetails->paymentType ) {
+				update_post_meta( $order_id, 'dibs_payment_type', $request->paymentDetails->paymentType );
+				update_post_meta( $order_id, 'dibs_customer_card', $request->paymentDetails->cardDetails->maskedPan );
+			}
+
+			// This function is run after WCS has created the subscription order. 
+			// Let's add the _dibs_recurring_token to the subscription as well.
+			if ( class_exists( 'WC_Subscription' ) && wcs_order_contains_subscription( $wc_order ) ) {
+				$subcriptions = wcs_get_subscriptions_for_order( $order_id );
+				foreach ( $subcriptions as $subcription ) {
+					update_post_meta( $subcription->get_id(), '_dibs_recurring_token', $dibs_order->payment->subscription->id );
+				}
+			}
+		}
+
+		return $dibs_order;
+	}
+
+	/**
+	 * Creates an order in DIBS from the recurring token saved.
+	 *
+	 * @param string $renewal_total The total price for the order.
+	 * @param object $renewal_order The WooCommerce order for the renewal.
+	 */
+	public function trigger_scheduled_payment( $renewal_total, $renewal_order ) {
+		$order_id = $renewal_order->get_id();
+		
+		// Get recurring token
+		$recurring_token = get_post_meta( $order_id, '_dibs_recurring_token', true );
+		if ( empty( $recurring_token ) ) {
+			$recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_dibs_recurring_token', true );
+			update_post_meta( $order_id, '_dibs_recurring_token', $recurring_token );
+		}
+
+		$create_order_response = new DIBS_Request_Charge_Subscription( $order_id );
+		$create_order_response = $create_order_response->request();
+
+		if ( !empty( $create_order_response->bulkId ) ) {
+			// We got a bulkId in response. Save it in the renewal order and make a new request to DIBS to get the status and ID of the transaction
+			update_post_meta( $order_id, '_dibs_recurring_bulk_id', $create_order_response->bulkId );
+
+			$recurring_orders = new DIBS_Request_Get_Subscription_Bulk_Id( $create_order_response->bulkId );
+			$recurring_orders = $recurring_orders->request();
+			
+			$payment_id = null;
+			foreach( $recurring_orders->page as $recurring_order ) {
+				if( $recurring_order->subscriptionId == $recurring_token ) {
+					$payment_id = $recurring_order->paymentId;
+					break;
+				}
+			}
+
+			if ( !empty( $payment_id ) ) {
+			
+				
+				if( 'Succeeded' == $recurring_order->status ) {
+					WC_Subscriptions_Manager::process_subscription_payments_on_order( $renewal_order );
+					$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
+					$renewal_order->payment_complete( $payment_id );
+				} else {
+					$renewal_order->add_order_note( sprintf( __( 'Payment status not available: Scheduling payment status check to be triggered in 1 minute.', 'dibs-easy-for-woocommerce' ), $payment_id ) );
+					wp_schedule_single_event( time() + 60, 'wc_dibs_easy_check_subscription_status', array( $order_id, $create_order_response->bulkId ) );
+				}
+				
+			} else {
+				WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $renewal_order );
+				$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS. Error code: %1$s. Message: %2$s', 'dibs-easy-for-woocommerce' ), 'fel', $create_order_response->bulkId ) );
+			}
+		}
+		
+		
+		
+		//error_log('$create_order_response ' . var_export($create_order_response, true));
+	}
+
+	/**
+	 * Creates an order in Klarna from the recurring token saved.
+	 *
+	 * @param string $renewal_total The total price for the order.
+	 * @param object $renewal_order The WooCommerce order for the renewal.
+	 */
+	public function check_subscription_status( $order_id, $subscription_bulk_id ) {
+		$order 				= wc_get_order( $order_id );
+		//$payment_id 		= $order->get_transaction_id();
+		$recurring_token 	= get_post_meta( $order_id, '_dibs_recurring_token', true );
+		
+		$recurring_orders = new DIBS_Request_Get_Subscription_Bulk_Id( $subscription_bulk_id );
+		$recurring_orders = $recurring_orders->request();
+		error_log('$recurring_orders in check_subscription_status ' . var_export($recurring_order_status, true));
+		$payment_id = null;
+		foreach( $recurring_orders->page as $recurring_order ) {
+			if( $recurring_order->subscriptionId == $recurring_token ) {
+				$payment_id = $recurring_order->paymentId;
+				break;
+			}
+		}
+
+		if ( !empty( $payment_id ) ) {
+		
+			
+			if( 'Succeeded' == $recurring_order->status ) {
+				WC_Subscriptions_Manager::process_subscription_payments_on_order( $order );
+				$order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
+				$order->payment_complete( $payment_id );
+			} else {
+				$order->add_order_note( sprintf( __( 'Payment status not correct for subscription. Status: %s', 'dibs-easy-for-woocommerce' ), $recurring_order->status ) );
+				WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $order );
+			}
+			
+		} else {
+			$order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS during scheduled request. No paymentId found in response', 'dibs-easy-for-woocommerce' ), 'fel' ) );
+		}
+	}
+
+	public function show_recurring_token( $order ) {
+		if ( 'shop_subscription' === $order->get_type() && get_post_meta( $order->get_id(), '_dibs_recurring_token' ) ) {
+			?>
+			<div class="order_data_column" style="clear:both; float:none; width:100%;">
+				<div class="address">
+					<?php
+						echo '<p><strong>' . __( 'DIBS recurring token' ) . ':</strong>' . get_post_meta( $order->id, '_dibs_recurring_token', true ) . '</p>';
+					?>
+				</div>
+				<div class="edit_address">
+					<?php
+						woocommerce_wp_text_input(
+							array(
+								'id'            => '_dibs_recurring_token',
+								'label'         => __( 'DIBS recurring token' ),
+								'wrapper_class' => '_billing_company_field',
+							)
+						);
+					?>
+				</div>
+			</div>
+		<?php
+		}
+	}
+
+	public function save_dibs_recurring_token_update( $post_id, $post ) {
+		$order = wc_get_order( $post_id );
+		if ( wcs_order_contains_subscription( $order ) && get_post_meta( $post_id, '_dibs_recurring_token' ) ) {
+			update_post_meta( $post_id, '_dibs_recurring_token', wc_clean( $_POST['_dibs_recurring_token'] ) );
+		}
+
+	}
+}
+new DIBS_Subscriptions();

--- a/classes/class-dibs-templates.php
+++ b/classes/class-dibs-templates.php
@@ -54,6 +54,12 @@ class DIBS_Templates {
 	 */
 	public function override_template( $template, $template_name, $template_path ) {
 		if ( is_checkout() ) {
+
+			// Don't display DIBS Easy template if we have a cart that doesn't needs payment
+			if ( ! WC()->cart->needs_payment() ) {
+				return $template;
+			}
+
 			if ( 'checkout/form-checkout.php' === $template_name ) {
 				$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 

--- a/classes/requests/class-dibs-requests-charge-subscription.php
+++ b/classes/requests/class-dibs-requests-charge-subscription.php
@@ -1,0 +1,68 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class DIBS_Request_Charge_Subscription extends DIBS_Requests2 {
+
+	public $order_id;
+
+	public function __construct( $order_id ) {
+		parent::__construct();
+
+		$this->order_id 		= $order_id;
+	}
+
+	public function request() {
+
+		$request_url = $this->endpoint . 'subscriptions/charges';
+
+		$response = wp_remote_request( $request_url, $this->get_request_args() );
+		if ( is_wp_error( $response ) ) {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+
+		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
+			DIBS_Easy::log( 'DIBS Charge subscription request response: ' . stripslashes_deep( json_encode( $response ) ) );
+			return json_decode( wp_remote_retrieve_body( $response ) );
+		} else {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+	}
+
+	public function get_request_args() {
+		$request_args = array(
+			'headers' => $this->request_headers(),
+			'method'  => 'POST',
+			'body'    => json_encode( $this->request_body() ),
+		);
+		DIBS_Easy::log( 'DIBS Charge Subscription request args: ' . json_encode( $request_args ) );
+		return apply_filters( 'dibs_easy_charge_subscription_args', $request_args );
+	}
+
+	public function request_body() {
+		$order = wc_get_order( $this->order_id );
+
+		$subscriptions = wcs_get_subscriptions_for_renewal_order( $this->order_id );
+		reset( $subscriptions );
+		$subscription_id = key( $subscriptions );
+
+		$recurring_token = get_post_meta( $this->order_id, '_dibs_recurring_token', true );
+		if ( empty( $recurring_token ) ) {
+			$recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $this->order_id ), '_dibs_recurring_token', true );
+			update_post_meta( $this->order_id, '_dibs_recurring_token', $recurring_token );
+		}
+
+		$body = array();
+		$body['externalBulkChargeId'] = $order->get_order_number();
+		$body['subscriptions'][0]['subscriptionId'] = $recurring_token;
+		$body['subscriptions'][0]['order']['items'] = DIBS_Requests_Get_Order_Items::get_items( $this->order_id );
+		$body['subscriptions'][0]['order']['amount'] = $order->get_total() * 100;
+		$body['subscriptions'][0]['order']['currency'] = $order->get_currency();
+		$body['subscriptions'][0]['order']['reference'] = $order->get_order_number();
+		
+		return $body;
+	}
+}

--- a/classes/requests/class-dibs-requests-create-dibs-order.php
+++ b/classes/requests/class-dibs-requests-create-dibs-order.php
@@ -32,13 +32,14 @@ class DIBS_Requests_Create_DIBS_Order extends DIBS_Requests2 {
 			'body'    => json_encode( $this->request_body() ),
 		);
 		DIBS_Easy::log( 'DIBS Create Order request args: ' . stripslashes_deep( json_encode( $request_args ) ) );
-		return apply_filters( 'dibs_easy_create_order_args', $request_args );
+		return $request_args;
 	}
 	public function request_body() {
-		return array(
+		$request_args = array(
 			'order'         => DIBS_Requests_Order::get_order(),
 			'checkout'      => DIBS_Requests_Checkout::get_checkout(),
 			'notifications' => DIBS_Requests_Notifications::get_notifications(),
 		);
+		return apply_filters( 'dibs_easy_create_order_args', $request_args );
 	}
 }

--- a/classes/requests/class-dibs-requests-get-subscription-bulk-charge-id.php
+++ b/classes/requests/class-dibs-requests-get-subscription-bulk-charge-id.php
@@ -1,0 +1,41 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+class DIBS_Request_Get_Subscription_Bulk_Id extends DIBS_Requests2 {
+
+	public $bulk_id;
+
+	public function __construct( $bulk_id ) {
+		$this->bulk_id = $bulk_id;
+		parent::__construct();
+	}
+
+	public function request() {
+		$request_url = $this->endpoint . 'subscriptions/charges/' . $this->bulk_id;
+		$request_args = $this->get_request_args();
+		DIBS_Easy::log( 'DIBS Get Subscription Bulk Charge ID args ('. $request_url . '): ' . stripslashes_deep( json_encode( $request_args ) ) );
+
+		$response = wp_remote_request( $request_url, $this->get_request_args() );
+		if ( is_wp_error( $response ) ) {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+
+		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
+			DIBS_Easy::log( 'DIBS  Get Subscription Bulk Charge ID response: ' . stripslashes_deep( json_encode( $response ) ) );
+			return json_decode( wp_remote_retrieve_body( $response ) );
+		} else {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+	}
+
+	public function get_request_args() {
+		$request_args = array(
+			'headers' => $this->request_headers(),
+			'method'  => 'GET',
+		);
+		return $request_args;
+	}
+}

--- a/classes/requests/class-dibs-requests-get-subscription.php
+++ b/classes/requests/class-dibs-requests-get-subscription.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+class DIBS_Requests_Get_Subscription extends DIBS_Requests2 {
+
+	public $subscription_id;
+
+	public function __construct( $subscription_id ) {
+		$this->subscription_id = $subscription_id;
+		parent::__construct();
+	}
+
+	public function request() {
+		$request_url = $this->endpoint . 'subscriptions/' . $this->subscription_id;
+
+		$response = wp_remote_request( $request_url, $this->get_request_args() );
+
+		DIBS_Easy::log( 'DIBS GET Subscription response (' . $request_url . '): ' . stripslashes_deep( json_encode( $response ) ) );
+
+		if ( is_wp_error( $response ) ) {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+
+		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
+			return json_decode( wp_remote_retrieve_body( $response ) );
+		} else {
+			$this->get_error_message( $response );
+			return 'ERROR';
+		}
+	}
+
+	public function get_request_args() {
+		$request_args = array(
+			'headers' => $this->request_headers(),
+			'method'  => 'GET',
+		);
+		DIBS_Easy::log( 'DIBS Get Subscription request args: ' . stripslashes_deep( json_encode( $request_args ) ) );
+
+		return $request_args;
+	}
+}

--- a/classes/requests/class-dibs-requests-update-dibs-order.php
+++ b/classes/requests/class-dibs-requests-update-dibs-order.php
@@ -16,15 +16,15 @@ class DIBS_Requests_Update_DIBS_Order extends DIBS_Requests2 {
 
 		$response = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $response ) ) {
-			$this->get_error_message( $response );
-			return 'ERROR';
+			return $this->get_error_message( $response );
+			//return 'ERROR';
 		}
 
 		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
 			return 'SUCCESS';
 		} else {
-			$this->get_error_message( $response );
-			return 'ERROR';
+			return $this->get_error_message( $response );
+			//return 'ERROR';
 		}
 	}
 

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -74,6 +74,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 			include_once plugin_basename( 'classes/class-dibs-api-callbacks.php' );
 			include_once plugin_basename( 'classes/class-dibs-templates.php' );
 			include_once plugin_basename( 'classes/class-dibs-create-local-order-fallback.php' );
+			include_once plugin_basename( 'classes/class-dibs-subscriptions.php' );
 
 			include_once plugin_basename( 'includes/dibs-country-converter-functions.php' );
 			include_once plugin_basename( 'includes/dibs-checkout-functions.php' );
@@ -86,6 +87,9 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 			include_once plugin_basename( 'classes/requests/class-dibs-requests-cancel-order.php' );
 			include_once plugin_basename( 'classes/requests/class-dibs-requests-refund-order.php' );
 			include_once plugin_basename( 'classes/requests/class-dibs-requests-get-dibs-order.php' );
+			include_once plugin_basename( 'classes/requests/class-dibs-requests-charge-subscription.php' );
+			include_once plugin_basename( 'classes/requests/class-dibs-requests-get-subscription-bulk-charge-id.php' );
+			include_once plugin_basename( 'classes/requests/class-dibs-requests-get-subscription.php' );
 
 			include_once plugin_basename( 'classes/requests/helpers/class-dibs-requests-get-checkout.php' );
 			include_once plugin_basename( 'classes/requests/helpers/class-dibs-requests-get-header.php' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -109,8 +109,6 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 			// Save DIBS data (payment id) in WC order
 			add_action( 'woocommerce_new_order', array( $this, 'save_dibs_order_data' ) );
 
-			// Save DIBS data (payment id) in WC order
-			add_filter( 'woocommerce_create_order', array( $this, 'save_cart_hash_to_order' ), 10, 2 );
 		}
 
 		// Include DIBS Gateway if WC_Payment_Gateway exist
@@ -348,28 +346,6 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 					update_post_meta( $order_id, '_dibs_payment_id', $payment_id );
 				}
 			}
-		}
-
-		/**
-		 * Saves DIBS data to WooCommerce order as meta field.
-		 *
-		 * @param string $order_id WooCommerce order id.
-		 * @param array    $data  Posted data.
-		 */
-		public function save_cart_hash_to_order( $order_id = null, $data ) {
-			if ( method_exists( WC()->session, 'get' ) ) {
-				
-				if( WC()->session->get( 'order_awaiting_payment' ) ) {
-					$order_id 	= absint( WC()->session->get( 'order_awaiting_payment' ) );
-					$cart_hash	= md5( wp_json_encode( wc_clean( WC()->cart->get_cart_for_session() ) ) . WC()->cart->total );
-					DIBS_Easy::log('Saving DIBS _cart_hash (in save_cart_hash_to_order) ' . $cart_hash . ' in order id ' . $order_id );
-					// Update cart hash
-					$order = wc_get_order( $order_id ) ;
-					$order->set_cart_hash( $cart_hash );
-					$order->save();
-				}
-			}
-			return null;
 		}
 
 		


### PR DESCRIPTION
* Subscription support.
* Catch and print error message better if update cart fails.
* Don't display DIBS Easy template if cart doesn’t needs_payment().
* Code cleaning. Remove save_cart_hash_to_order().
* Try to finalize order in Woo earlier. In process_payment() instead of woocommerce_thankyou_dibs_easy()