### PR TITLE
1.6.2

### DIFF
--- a/classes/requests/helpers/class-dibs-requests-get-checkout.php
+++ b/classes/requests/helpers/class-dibs-requests-get-checkout.php
@@ -14,7 +14,7 @@ class DIBS_Requests_Checkout {
 			),
 		);
 		if ( 'all' !== get_option( 'woocommerce_allowed_countries' ) ) {
-			$checkout['ShippingCountries'] = self::get_shipping_countries();
+			$checkout['shipping']['countries'] = self::get_shipping_countries();
 		}
 		$dibs_settings          = get_option( 'woocommerce_dibs_easy_settings' );
 		$allowed_customer_types = ( isset( $dibs_settings['allowed_customer_types'] ) ) ? $dibs_settings['allowed_customer_types'] : 'B2C';
@@ -43,19 +43,14 @@ class DIBS_Requests_Checkout {
 	public static function get_shipping_countries() {
 		$converted_countries      = array();
 		$supported_dibs_countries = dibs_get_supported_countries();
-		// Add shipping countries
+		// Add shipping countries.
 		$wc_countries = new WC_Countries();
 		$countries    = array_keys( $wc_countries->get_allowed_countries() );
-		$i            = 0;
+
 		foreach ( $countries as $country ) {
 			$converted_country = dibs_get_iso_3_country( $country );
 			if ( in_array( $converted_country, $supported_dibs_countries ) ) {
 				$converted_countries[] = array( 'countryCode' => $converted_country );
-				$i++;
-				// DIBS only allow 5 countries
-				if ( $i == 5 ) {
-					break;
-				}
 			}
 		}
 		return $converted_countries;

--- a/classes/requests/helpers/class-dibs-requests-get-header.php
+++ b/classes/requests/helpers/class-dibs-requests-get-header.php
@@ -5,9 +5,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class DIBS_Requests_Header extends DIBS_Requests2 {
 	public function get() {
 		$formatted_request_header = array(
-			'Content-type'  => 'application/json',
-			'Accept'        => 'application/json',
-			'Authorization' => $this->key,
+			'Content-type'        => 'application/json',
+			'Accept'              => 'application/json',
+			'Authorization'       => $this->key,
+			'commercePlatformTag' => 'WooEasyKrokedil',
 		);
 		return $formatted_request_header;
 	}

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             DIBS Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
- * Version:                 1.6.1
+ * Version:                 1.6.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    3.0.0
- * WC tested up to:         3.5.1
+ * WC tested up to:         3.5.2
  * Copyright:               © 2017-2018 Krokedil Produktionsbyrå AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.6.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.6.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/includes/dibs-checkout-functions.php
+++ b/includes/dibs-checkout-functions.php
@@ -193,8 +193,8 @@ function wc_dibs_get_private_key() {
 }
 
 function wc_dibs_clean_name( $name ) {
-	$name = preg_replace( '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9åäöüÅÄÖÜØÆøæéÉèÈ\s]+/i', '', $name );
-
+	$regex = '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9\x{00A1}-\x{00AC}\x{00AE}-\x{00FF}\x{0100}-\x{017F}\x{0180}-\x{024F}\x{0250}-\x{02AF}\x{02B0}-\x{02FF}\x{0300}-\x{036F}\s]+/u';
+	$name  = preg_replace( $regex, '', $name );
 	return $name;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy
 Requires at least: 4.7
-Tested up to: 4.9.8
+Tested up to: 5.0
 Stable tag: trunk
 Requires WooCommerce at least: 3.0
-Tested WooCommerce up to: 3.5.1
+Tested WooCommerce up to: 3.5.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -55,6 +55,13 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 * This plugin integrates with DIBS Easy. You need an agreement with DIBS specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2018.12.03    - version 1.6.2 =
+* Tweak			- Added WooEasyKrokedil as commercePlatformTag in header sent to DIBS.
+* Tweak			- Plugin WordPress 5.0 compatible.
+* Fix			- Updated how available shipping countries are sent to DIBS to reflect DIBS API changes.
+* Fix			- Do not limit number of shipping countries to 5. No limits in DIBS API anymore. 
+* Fix			- Improved handling of allowed characters in product names sent to DIBS. Also added unicode handler.
 
 = 2018.11.21    - version 1.6.1 =
 * Fix			- Bug fix in logic for user must login message (after customer_adress_updated event has been triggered).


### PR DESCRIPTION
* Tweak - Added WooEasyKrokedil as commercePlatformTag in header sent to DIBS.
* Tweak - Plugin WordPress 5.0 compatible.
* Fix - Updated how available shipping countries are sent to DIBS to reflect DIBS API changes.
* Fix - Do not limit number of shipping countries to 5. No limits in DIBS API anymore. 
* Fix - Improved handling of allowed characters in product names sent to DIBS. Also added unicode handler.