### PR TITLE
1.7.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ######################
 .DS_Store
 .DS_Store?
+SyncToy_14829309-94bf-4956-86dd-41b3413f9a7c.dat

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -10,6 +10,7 @@
         if ("dibs_easy" === $("input[name='payment_method']:checked").val() ) {
             removeStandardOrderNote();
             addressChangedListener();
+            paymentInitializedListener();
             paymentCompletedListener();
         }
     });
@@ -63,6 +64,15 @@
                     }
                 );
             }
+        });
+    }
+
+    // When customer clicks Pay button in Easy. Before redirect to 3DSecure.
+    function paymentInitializedListener() {
+        dibsCheckout.on('pay-initialized', function(response) {
+            $(document.body).trigger('dibs_pay_initialized');
+            console.log('dibs_pay_initialized');
+            dibsCheckout.send('payment-order-finalized', true);
         });
     }
 

--- a/classes/class-dibs-easy-gateway.php
+++ b/classes/class-dibs-easy-gateway.php
@@ -212,12 +212,17 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 			do_action( 'dibs_easy_process_payment', $order_id, $request );
 
 			update_post_meta( $order_id, 'dibs_payment_type', $request->payment->paymentDetails->paymentType );
+			update_post_meta( $order_id, 'dibs_payment_method', $request->payment->paymentDetails->paymentMethod );
 
 			if ( 'CARD' == $request->payment->paymentDetails->paymentType ) {
 				update_post_meta( $order_id, 'dibs_customer_card', $request->payment->paymentDetails->cardDetails->maskedPan );
 			}
 
-			$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
+			if ( 'A2A' === $request->payment->paymentDetails->paymentType ) {
+				$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentMethod ) );
+			} else {
+				$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
+			}
 			$order->payment_complete( $payment_id );
 		}
 		$this->maybe_add_invoice_fee( $order_id );

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -24,6 +24,11 @@ class DIBS_Post_Checkout {
 		$gateway_used = get_post_meta( $order_id, '_payment_method', true );
 		if ( 'dibs_easy' === $gateway_used ) {
 
+			// Bail if we already have charged the order once in DIBS system.
+			if ( get_post_meta( $order_id, '_dibs_charge_id', true ) ) {
+				return;
+			}
+
 			$payment_type = get_post_meta( $order_id, 'dibs_payment_type', true );
 			if ( 'A2A' === $payment_type ) {
 				// This is a account to account purchase (like Swish). No activation is needed/possible.
@@ -35,27 +40,26 @@ class DIBS_Post_Checkout {
 			$request = new DIBS_Requests_Activate_Order( $order_id );
 			$request = json_decode( $request->request() );
 
-			// Error handling
+			// Error handling.
 			if ( null != $request ) {
 				if ( array_key_exists( 'chargeId', $request ) ) { // Payment success
 					$wc_order->add_order_note( sprintf( __( 'Payment made in DIBS with charge ID %s', 'dibs-easy-for-woocommerce' ), $request->chargeId ) );
 
 					update_post_meta( $order_id, '_dibs_charge_id', $request->chargeId );
-				} elseif ( array_key_exists( 'errors', $request ) ) { // Response with errors
-					if ( array_key_exists( 'instance', $request->errors ) && 'cannot be null' === $request->errors->instance[0] ) { // If return is empty
-						$this->charge_failed( $wc_order, true );
+				} elseif ( array_key_exists( 'errors', $request ) ) { // Response with errors.
+					if ( array_key_exists( 'instance', $request->errors ) ) { // If return is empty.
+						$message = $request->errors->instance[0];
+					} elseif ( array_key_exists( 'amount', $request->errors ) ) { // If total amount is wrong.
+						$message = $request->errors->amount[0];
+					} else {
+						$message = wp_json_encode( $request->errors );
 					}
-					if ( array_key_exists( 'amount', $request->errors ) && 'Amount must be greater than 0' === $request->errors->amount[0] ) { // If total amount equals 0
-						$message = 'Total amount equal 0';
-						$this->charge_failed( $wc_order, true, $message );
-					}
-					if ( array_key_exists( 'amount', $request->errors ) && 'Amount dosen\'t match sum of orderitems' === $request->errors->amount[0] ) { // If the total amount does not equal the line items total
-						$message = 'Order total amount does not match the order items';
-						$this->charge_failed( $wc_order, true, $message );
-					}
-				} elseif ( array_key_exists( 'code', $request ) && '1001' == $request->code ) { // Response with error code for overcharged order
-					$message = 'Payment overcharged';
-					$this->charge_failed( $wc_order, false, $request->message );
+
+					$this->charge_failed( $wc_order, true, $message );
+
+				} elseif ( array_key_exists( 'code', $request ) && '1001' == $request->code ) { // Response with error code for overcharged order.
+					update_post_meta( $order_id, '_dibs_charge_id', 'Charge error: ' . $request->code );
+					$this->charge_failed( $wc_order, true, $request->message );
 				} else {
 					$this->charge_failed( $wc_order );
 				}
@@ -94,7 +98,7 @@ class DIBS_Post_Checkout {
 	public function charge_failed( $order, $fail = true, $message = 'Payment failed in DIBS' ) {
 		$order->add_order_note( sprintf( __( 'DIBS Error: %s', 'dibs-easy-for-woocommerce' ), $message ) );
 		if ( true === $fail ) {
-			$order->update_status( 'processing' );
+			$order->update_status( apply_filters( 'dibs_easy_failed_charge_status', 'on-hold', $order ) );
 			$order->save();
 		}
 	}

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -62,18 +62,18 @@ class DIBS_Post_Checkout {
 
 			$request = new DIBS_Requests_Cancel_Order( $order_id );
 			$request = json_decode( $request->request() );
-			
+
 			$wc_order = wc_get_order( $order_id );
 
 			if ( null === $request ) {
 				$wc_order->add_order_note( sprintf( __( 'Order has been canceled in DIBS', 'dibs-easy-for-woocommerce' ) ) );
 			} else {
-				if( array_key_exists( 'errors', $request ) ) {
-					$message = json_encode($request->errors);
-				} elseif(  array_key_exists( 'message', $request ) ) {
-					$message = json_encode($request->message);
+				if ( array_key_exists( 'errors', $request ) ) {
+					$message = json_encode( $request->errors );
+				} elseif ( array_key_exists( 'message', $request ) ) {
+					$message = json_encode( $request->message );
 				} else {
-					$message = json_encode($request);
+					$message = json_encode( $request );
 				}
 				$wc_order->add_order_note( sprintf( __( 'There was a problem canceling the order in DIBS: %s', 'dibs-easy-for-woocommerce' ), $message ) );
 			}

--- a/classes/requests/helpers/class-dibs-requests-get-notifications.php
+++ b/classes/requests/helpers/class-dibs-requests-get-notifications.php
@@ -11,12 +11,12 @@ class DIBS_Requests_Notifications {
 	}
 
 	public static function get_web_hooks() {
-		$web_hooks   = array();
-		$web_hooks[] = array(
-			'eventName'     => 'payment.reservation.created',
-			'url'           => add_query_arg( array( 'dibs-payment-created-callback' =>'1' ), get_home_url() . '/wc-api/DIBS_Api_Callbacks/' ),
-			'authorization' => wp_create_nonce( 'dibs_web_hooks' ),
-		);
+		$web_hooks       = array();
+			$web_hooks[] = array(
+				'eventName'     => 'payment.checkout.completed',
+				'url'           => add_query_arg( array( 'dibs-payment-created-callback' => '1' ), get_home_url() . '/wc-api/DIBS_Api_Callbacks/' ),
+				'authorization' => wp_create_nonce( 'dibs_web_hooks' ),
+			);
 		return $web_hooks;
 	}
 }

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             DIBS Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
- * Version:                 1.7.4
+ * Version:                 1.7.5
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.7.4' );
+define( 'WC_DIBS_EASY_VERSION', '1.7.5' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,15 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2019.05.01    - version 1.7.5 =
+* Tweak         - Added listener for pay-initialized + added JS event dibs_pay_initialized.
+* Tweak         - Change callback listener for order from payment.reservation.created to payment.checkout.completed webhook (because of Swish intoduction).
+* Tweak         - Order management: Don't try to make a charge request if payment_type is A2A (Swish and other account 2 account purchases).
+* Tweak         - Order management: Don't try to charge if we already have a charge ID.
+* Tweak         - Order management: Make sure we add an order note if charge fails.
+* Tweak         - Order management: Set order status to On hold if charge fails (the first time). If trying to activate the order again, Woo order status will be set to Completed.
+* Tweak         - Order management: Added filter dibs_easy_failed_charge_status so other plugins can change the status the Woo order is set to if charge request fails.
+
 = 2019.04.10    - version 1.7.4 =
 * Tweak         - Added filters dibs_easy_request_checkout_key & dibs_easy_request_secret_key to be able to modify merchant ID sent to DIBS.
 * Fix           - Added check for chargedAmount when completing payment in Woo. Fixes so order status is set to Processing with Swish payments.


### PR DESCRIPTION
* Tweak - Added listener for pay-initialized + added JS event dibs_pay_initialized.
* Tweak - Change callback listener for order from payment.reservation.created to payment.checkout.completed webhook (because of Swish intoduction).
* Tweak - Order management: Don't try to make a charge request if payment_type is A2A (Swish and other account 2 account purchases).
* Tweak - Order management: Don't try to charge if we already have a charge ID.
* Tweak - Order management: Make sure we add an order note if charge fails.
* Tweak - Order management: Set order status to On hold if charge fails (the first time). If trying to activate the order again, Woo order status will be set to Completed.
* Tweak - Order management: Added filter dibs_easy_failed_charge_status so other plugins can change the status the Woo order is set to if charge request fails.