### PR TITLE
Develop - renewal subscription

### DIFF
--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -38,7 +38,7 @@ class DIBS_Subscriptions {
 	 */
 	public function maybe_add_subscription( $request_args ) {
 		// Check if we have a subscription product. If yes set recurring field.
-		if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && ( wcs_cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
 			$request_args['subscription'] = array(
 				'endDate'  => date( 'Y-m-d\TH:i', strtotime( '+150 year' ) ),
 				'interval' => 0,

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -38,7 +38,7 @@ class DIBS_Subscriptions {
 	 */
 	public function maybe_add_subscription( $request_args ) {
 		// Check if we have a subscription product. If yes set recurring field.
-		if ( class_exists( 'WC_Subscriptions_Cart' ) && ( wcs_cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
 			$request_args['subscription'] = array(
 				'endDate'  => date( 'Y-m-d\TH:i', strtotime( '+150 year' ) ),
 				'interval' => 0,
@@ -66,8 +66,8 @@ class DIBS_Subscriptions {
 
 			// This function is run after WCS has created the subscription order.
 			// Let's add the _dibs_recurring_token to the subscription as well.
-			if ( class_exists( 'WC_Subscription' ) && wcs_order_contains_subscription( $wc_order ) ) {
-				$subcriptions = wcs_get_subscriptions_for_order( $order_id );
+			if ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) {
+				$subcriptions = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'any' ) );
 				foreach ( $subcriptions as $subcription ) {
 					update_post_meta( $subcription->get_id(), '_dibs_recurring_token', $dibs_order->payment->subscription->id );
 				}


### PR DESCRIPTION
If a subscription renewal failes (for instance because of the saved card had expired or similar), this creates a flow where the customer gets an email with a pay-link. 

When paying for this renewal (manually by the customer), this should create a new recurring/subscription id in DIBS system. That did not happen. The order was treated as a regular order. This PR fixes this issue. The renewal order creates a new recurring ID that is stored in the renewal order and in the original subscription.