### PR TITLE
1.10.2

### DIFF
--- a/classes/class-dibs-admin-notices.php
+++ b/classes/class-dibs-admin-notices.php
@@ -16,9 +16,9 @@ class DIBS_Easy_Admin_Notices {
 	 * DIBS_Easy_Admin_Notices constructor.
 	 */
 	public function __construct() {
-		$dibs_easy_settings  = get_option( 'woocommerce_dibs_easy_settings' );
-		$this->enabled       = $dibs_easy_settings['enabled'];
-		$this->checkout_flow = $dibs_easy_settings['checkout_flow'];
+		$this->settings      = get_option( 'woocommerce_dibs_easy_settings' );
+		$this->enabled       = ( isset( $this->settings['enabled'] ) ) ? $this->settings['enabled'] : '';
+		$this->checkout_flow = ( isset( $this->settings['checkout_flow'] ) ) ? $this->settings['checkout_flow'] : 'embedded';
 		add_action( 'admin_init', array( $this, 'check_settings' ) );
 	}
 	public function check_settings() {

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             DIBS Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
- * Version:                 1.10.1
+ * Version:                 1.10.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.10.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.10.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,9 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2019.08.07    - version 1.10.2 =
+* Fix           - Avoid notices/headers already sent issue in admin notice if plugin settings doesn't exist yet.
+
 = 2019.08.07    - version 1.10.1 =
 * Tweak         - Added message to order note if recurring payment fails.
 * Tweak         - Only display admin notice about recommended account settings if Embedded is the selected checkout flow.


### PR DESCRIPTION
* Fix - Avoid notices/headers already sent issue in admin notice if plugin settings doesn't exist yet.