### PR TITLE
1.13.0

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -203,7 +203,6 @@ jQuery(function($) {
 
 				dibsCheckout.send('payment-order-finalized', true);
             }
-            dibs_wc.dibsOrderProcessing = false;
         },
         
         /*
@@ -464,10 +463,10 @@ jQuery(function($) {
             }
         );
     });
-    
+
     // When payment method is changed
-    if ( true !== dibs_wc.dibsOrderProcessing ) {
-        $(document).on("change", "input[name='payment_method']", function (event) {
+    $(document).on("change", "input[name='payment_method']", function (event) {
+        if ( true !== dibs_wc.dibsOrderProcessing ) {
             if ( "dibs_easy" === $("input[name='payment_method']:checked").val() ) {	
                 $.ajax(
                     wc_dibs_easy.change_payment_method_url,
@@ -492,8 +491,8 @@ jQuery(function($) {
                     }
                 );
             }
-        });
-    }
+        }
+    });
     
     // When WooCommerce checkout submission fails
 	$(document).on("checkout_error", function () {

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -12,7 +12,7 @@ jQuery(function($) {
 		extraFieldsSelectorNonText: 'div#dibs-extra-checkout-fields select, div#dibs-extra-checkout-fields input[type="radio"], div#dibs-extra-checkout-fields input[type="checkbox"], div#dibs-extra-checkout-fields input.checkout-date-picker, input#terms input[type="checkbox"]',
 
         // Dibs processing order.
-        dibsOrderProcessing = false,
+        dibsOrderProcessing: false,
 
         /*
 		 * Document ready function. 

--- a/classes/class-dibs-admin-notices.php
+++ b/classes/class-dibs-admin-notices.php
@@ -42,7 +42,7 @@ class DIBS_Easy_Admin_Notices {
 		// Terms page
 		if ( ! wc_get_page_id( 'terms' ) || wc_get_page_id( 'terms' ) < 0 ) {
 			echo '<div class="notice notice-error">';
-			echo '<p>' . sprintf( __( 'You need to <a href="%s" target="_blank">specify a terms page</a> in WooCommerce Settings to be able to use DIBS Easy.', 'dibs-easy-for-woocommerce' ), 'https://docs.woocommerce.com/document/configuring-woocommerce-settings/#section-14' ) . '</p>';
+			echo '<p>' . sprintf( __( 'You need to <a href="%s" target="_blank">specify a terms page</a> in WooCommerce Settings to be able to use Nets Easy.', 'dibs-easy-for-woocommerce' ), 'https://docs.woocommerce.com/document/configuring-woocommerce-settings/#section-14' ) . '</p>';
 			echo '</div>';
 		}
 	}
@@ -56,7 +56,7 @@ class DIBS_Easy_Admin_Notices {
 		}
 		if ( ! is_ssl() ) {
 			echo '<div class="notice notice-error">';
-			echo '<p>' . esc_html( __( 'You need to enable and configure https to be able to use DIBS Easy.', 'dibs-easy-for-woocommerce' ) ) . '</p>';
+			echo '<p>' . esc_html( __( 'You need to enable and configure https to be able to use Nets Easy.', 'dibs-easy-for-woocommerce' ) ) . '</p>';
 			echo '</div>';
 		}
 	}
@@ -71,13 +71,13 @@ class DIBS_Easy_Admin_Notices {
 		// Account page - username.
 		if ( 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ) && 'no' === get_option( 'woocommerce_registration_generate_username' ) ) {
 			echo '<div class="notice notice-error">';
-			echo '<p>' . sprintf( __( 'To be able to use DIBS Easy correctly you need to tick the checkbox <i>When creating an account, automatically generate a username from the customer\'s email address</i> when having the <i>Allow customers to create an account during checkout</i> setting activated. This can be changed in the <a href="%s">Accounts & Privacy tab</a>.', 'dibs-easy-for-woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=account' ) ) . '</p>';
+			echo '<p>' . sprintf( __( 'To be able to use Nets Easy correctly you need to tick the checkbox <i>When creating an account, automatically generate a username from the customer\'s email address</i> when having the <i>Allow customers to create an account during checkout</i> setting activated. This can be changed in the <a href="%s">Accounts & Privacy tab</a>.', 'dibs-easy-for-woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=account' ) ) . '</p>';
 			echo '</div>';
 		}
 		// Account page - password.
 		if ( 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ) && 'no' === get_option( 'woocommerce_registration_generate_password' ) ) {
 			echo '<div class="notice notice-error">';
-			echo '<p>' . sprintf( __( 'To be able to use DIBS Easy correctly you need to tick the checkbox <i>When creating an account, automatically generate an account password</i> when having the <i>Allow customers to create an account during checkout</i> setting activated. This can be changed in the <a href="%s">Accounts & Privacy tab</a>.', 'dibs-easy-for-woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=account' ) ) . '</p>';
+			echo '<p>' . sprintf( __( 'To be able to use Nets Easy correctly you need to tick the checkbox <i>When creating an account, automatically generate an account password</i> when having the <i>Allow customers to create an account during checkout</i> setting activated. This can be changed in the <a href="%s">Accounts & Privacy tab</a>.', 'dibs-easy-for-woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=account' ) ) . '</p>';
 			echo '</div>';
 		}
 	}

--- a/classes/class-dibs-ajax-calls.php
+++ b/classes/class-dibs-ajax-calls.php
@@ -83,13 +83,13 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 			exit( 'Nonce can not be verified.' );
 		}
 		*/
-		$update_needed      = 'yes';
+		$update_needed      = 'no';
 		$must_login         = 'no';
 		$must_login_message = apply_filters( 'woocommerce_registration_error_email_exists', __( 'An account is already registered with your email address. Please log in.', 'woocommerce' ) );
 
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 
-		// Get customer data from Collector
+		// Get customer data from DIBS
 		$country   = dibs_get_iso_2_country( $_REQUEST['address']['countryCode'] );
 		$post_code = $_REQUEST['address']['postalCode'];
 
@@ -106,13 +106,12 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 		}
 
 		if ( $country ) {
-
-			// If country is changed then we need to trigger an cart update in the Collector Checkout
+			// If country is changed then we need to trigger an cart update in the DIBS Easy Checkout
 			if ( WC()->customer->get_billing_country() !== $country ) {
 				$update_needed = 'yes';
 			}
 
-			// If country is changed then we need to trigger an cart update in the Collector Checkout
+			// If country is changed then we need to trigger an cart update in the DIBS Easy Checkout
 			if ( WC()->customer->get_shipping_postcode() !== $post_code ) {
 				$update_needed = 'yes';
 			}

--- a/classes/class-dibs-ajax-calls.php
+++ b/classes/class-dibs-ajax-calls.php
@@ -188,10 +188,10 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 			if ( is_wp_error( $response ) ) {
 				$message = $response->get_error_message();
 			} else {
-				$message = 'Empty response from DIBS.';
+				$message = 'Empty response from Nets.';
 			}
 
-			DIBS_Easy::log( 'Confirmation page rendered for DIBS payment ID ' . $payment_id . ', but something went wrong. WooCommerce form not submitted. Error message: ' . var_export( $message, true ) );
+			DIBS_Easy::log( 'Confirmation page rendered for Nets payment ID ' . $payment_id . ', but something went wrong. WooCommerce form not submitted. Error message: ' . var_export( $message, true ) );
 
 			// @todo - log and/or improve this error response?
 			wp_send_json_error( $message );
@@ -206,7 +206,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 			// Store the order data in a sesstion. We might need it if form processing in Woo fails
 			WC()->session->set( 'dibs_order_data', $response );
 
-			DIBS_Easy::log( 'Confirmation page rendered and checkout form about to be submitted for DIBS payment ID ' . $payment_id );
+			DIBS_Easy::log( 'Confirmation page rendered and checkout form about to be submitted for Nets payment ID ' . $payment_id );
 
 			self::prepare_cart_before_form_processing( $response->payment->consumer->shippingAddress->country );
 			wp_send_json_success( $response );

--- a/classes/class-dibs-api-callbacks.php
+++ b/classes/class-dibs-api-callbacks.php
@@ -144,9 +144,11 @@ class DIBS_Api_Callbacks {
 			// Get DIBS Payment meta and save it in the order.
 			$request  = new DIBS_Requests_Get_DIBS_Order( $data['data']['paymentId'] );
 			$response = $request->request();
-			if ( is_wp_error( $response ) || empty( $response ) ) {
-				update_post_meta( $order->get_id(), 'dibs_payment_type', $request->payment->paymentDetails->paymentType );
-				update_post_meta( $order->get_id(), 'dibs_payment_method', $request->payment->paymentDetails->paymentMethod );
+			if ( is_wp_error( $response ) ) {
+				$order->add_order_note( sprintf( __( 'Failed trying to receive the order from DIBS. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $response->get_error_message() ) ) );
+			} else {
+				update_post_meta( $order->get_id(), 'dibs_payment_type', $response->payment->paymentDetails->paymentType );
+				update_post_meta( $order->get_id(), 'dibs_payment_method', $response->payment->paymentDetails->paymentMethod );
 			}
 			update_post_meta( $order->get_id(), '_dibs_date_paid', date( 'Y-m-d H:i:s' ) );
 			$order->payment_complete( $data['data']['paymentId'] );

--- a/classes/class-dibs-api-callbacks.php
+++ b/classes/class-dibs-api-callbacks.php
@@ -145,14 +145,14 @@ class DIBS_Api_Callbacks {
 			$request  = new DIBS_Requests_Get_DIBS_Order( $data['data']['paymentId'] );
 			$response = $request->request();
 			if ( is_wp_error( $response ) ) {
-				$order->add_order_note( sprintf( __( 'Failed trying to receive the order from DIBS. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $response->get_error_message() ) ) );
+				$order->add_order_note( sprintf( __( 'Failed trying to receive the order from Nets. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $response->get_error_message() ) ) );
 			} else {
 				update_post_meta( $order->get_id(), 'dibs_payment_type', $response->payment->paymentDetails->paymentType );
 				update_post_meta( $order->get_id(), 'dibs_payment_method', $response->payment->paymentDetails->paymentMethod );
 			}
 			update_post_meta( $order->get_id(), '_dibs_date_paid', date( 'Y-m-d H:i:s' ) );
 			$order->payment_complete( $data['data']['paymentId'] );
-			$order->add_order_note( 'Payment via DIBS Easy. Order status updated via API callback. Payment ID: ' . sanitize_key( $data['data']['paymentId'] ) );
+			$order->add_order_note( 'Payment via Nets Easy. Order status updated via API callback. Payment ID: ' . sanitize_key( $data['data']['paymentId'] ) );
 			DIBS_Easy::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed in API callback.' );
 
 		} else {
@@ -173,12 +173,12 @@ class DIBS_Api_Callbacks {
 		$dibs_order_total = $dibs_order['data']['order']['amount']['amount'];
 
 		if ( $woo_order_total > $dibs_order_total && ( $woo_order_total - $dibs_order_total ) > 30 ) {
-			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review. WooCommerce order total and DIBS order total do not match. DIBS order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_order_total ) );
-			DIBS_Easy::log( 'Order total missmatch in order:' . $order->get_order_number() . '. Woo order total: ' . $woo_order_total . '. DIBS order total: ' . $dibs_order_total );
+			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review. WooCommerce order total and Nets order total do not match. Nets order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_order_total ) );
+			DIBS_Easy::log( 'Order total missmatch in order:' . $order->get_order_number() . '. Woo order total: ' . $woo_order_total . '. Nets order total: ' . $dibs_order_total );
 			$order_totals_match = false;
 		} elseif ( $dibs_order_total > $woo_order_total && ( $dibs_order_total - $woo_order_total ) > 30 ) {
-			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review. WooCommerce order total and DIBS order total do not match. DIBS order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_order_total ) );
-			DIBS_Easy::log( 'Order total missmatch in order:' . $order->get_order_number() . '. Woo order total: ' . $woo_order_total . '. DIBS order total: ' . $dibs_order_total );
+			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review. WooCommerce order total and Nets order total do not match. Nets order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_order_total ) );
+			DIBS_Easy::log( 'Order total missmatch in order:' . $order->get_order_number() . '. Woo order total: ' . $woo_order_total . '. Nets order total: ' . $dibs_order_total );
 			$order_totals_match = false;
 		}
 
@@ -289,7 +289,7 @@ class DIBS_Api_Callbacks {
 		$order->set_shipping_tax( self::get_shipping_tax_total( $dibs_checkout_completed_order ) );
 		$order->set_total( $dibs_checkout_completed_order['data']['order']['amount']['amount'] / 100 );
 
-		$order->add_order_note( __( 'Order created via DIBS Easy API callback. Please verify the order in DIBS system.', 'dibs-easy-for-woocommerce' ) );
+		$order->add_order_note( __( 'Order created via Nets Easy API callback. Please verify the order in Nets system.', 'dibs-easy-for-woocommerce' ) );
 
 		// Make sure to run Sequential Order numbers if plugin exsists.
 		if ( class_exists( 'WC_Seq_Order_Number_Pro' ) ) {
@@ -308,9 +308,9 @@ class DIBS_Api_Callbacks {
 			update_post_meta( $order_id, 'dibs_customer_card', $dibs_order->payment->paymentDetails->cardDetails->maskedPan );
 		}
 		if ( 'A2A' === $dibs_order->payment->paymentDetails->paymentType ) {
-			$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $dibs_order->payment->paymentId, $dibs_order->payment->paymentDetails->paymentMethod ) );
+			$order->add_order_note( sprintf( __( 'Order made in Nets with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $dibs_order->payment->paymentId, $dibs_order->payment->paymentDetails->paymentMethod ) );
 		} else {
-			$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $dibs_order->payment->paymentId, $dibs_order->payment->paymentDetails->paymentType ) );
+			$order->add_order_note( sprintf( __( 'Order made in Nets with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $dibs_order->payment->paymentId, $dibs_order->payment->paymentDetails->paymentType ) );
 		}
 
 		$order->calculate_totals();
@@ -321,7 +321,7 @@ class DIBS_Api_Callbacks {
 		}
 
 		if ( (int) round( $order->get_total() * 100 ) !== (int) $dibs_checkout_completed_order['data']['order']['amount']['amount'] ) {
-			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review, WooCommerce total and DIBS total do not match. DIBS order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_checkout_completed_order['data']['order']['amount']['amount'] ) );
+			$order->update_status( 'on-hold', sprintf( __( 'Order needs manual review, WooCommerce total and Nets total do not match. Nets order total: %s.', 'dibs-easy-for-woocommerce' ), $dibs_checkout_completed_order['data']['order']['amount']['amount'] ) );
 		}
 
 		return $order;
@@ -336,7 +336,7 @@ class DIBS_Api_Callbacks {
 	 * @throws Exception WC_Data_Exception.
 	 */
 	private function process_order_lines( $dibs_checkout_completed_order, $order ) {
-		DIBS_Easy::log( 'Processing order lines (from DIBS order) during backup order creation for DIBS payment ID ' . $dibs_checkout_completed_order['data']['paymentId'] );
+		DIBS_Easy::log( 'Processing order lines (from Nets order) during backup order creation for Nets payment ID ' . $dibs_checkout_completed_order['data']['paymentId'] );
 		foreach ( $dibs_checkout_completed_order['data']['order']['orderItems'] as $cart_item ) {
 
 			if ( strpos( $cart_item['reference'], 'shipping|' ) !== false ) {

--- a/classes/class-dibs-easy-gateway.php
+++ b/classes/class-dibs-easy-gateway.php
@@ -10,9 +10,9 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 	public function __construct() {
 		$this->id = 'dibs_easy';
 
-		$this->method_title = __( 'DIBS Easy', 'dibs-easy-for-woocommerce' );
+		$this->method_title = __( 'Nets Easy', 'dibs-easy-for-woocommerce' );
 
-		$this->method_description = __( 'DIBS Easy Payment for checkout', 'dibs-easy-for-woocommerce' );
+		$this->method_description = __( 'Nets Easy Payment for checkout', 'dibs-easy-for-woocommerce' );
 
 		// Load the form fields.
 		$this->init_form_fields();
@@ -53,7 +53,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 	public function get_icon() {
 		$icon_src   = 'https://cdn.dibspayment.com/logo/checkout/combo/horiz/DIBS_checkout_kombo_horizontal_04.png';
 		$icon_width = '145';
-		$icon_html  = '<img src="' . $icon_src . '" alt="DIBS - Payments made easy" style="max-width:' . $icon_width . 'px"/>';
+		$icon_html  = '<img src="' . $icon_src . '" alt="Nets - Payments made easy" style="max-width:' . $icon_width . 'px"/>';
 		return apply_filters( 'wc_dibs_easy_icon_html', $icon_html );
 	}
 
@@ -106,7 +106,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 
 			if ( array_key_exists( 'hostedPaymentPageUrl', $response ) ) {
 				// All good. Redirect customer to DIBS payment page.
-				$order->add_order_note( __( 'Customer redirected to DIBS payment page.', 'dibs-easy-for-woocommerce' ) );
+				$order->add_order_note( __( 'Customer redirected to Nets payment page.', 'dibs-easy-for-woocommerce' ) );
 				update_post_meta( $order_id, '_dibs_payment_id', $response->paymentId );
 				return array(
 					'result'   => 'success',
@@ -122,7 +122,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 						$error_message = json_decode( $error_message );
 					}
 				} else {
-					$error_message = __( 'An error occured during communication with DIBS. Please try again.', 'dibs-easy-for-woocommerce' );
+					$error_message = __( 'An error occured during communication with Nets. Please try again.', 'dibs-easy-for-woocommerce' );
 				}
 				wc_add_notice( sprintf( __( '%s', 'dibs-easy-for-woocommerce' ), wp_json_encode( $error_message ) ), 'error' );
 				return false;
@@ -170,7 +170,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 		$request = json_decode( $request->request() );
 
 		if ( array_key_exists( 'refundId', $request ) ) { // Payment success
-			$order->add_order_note( sprintf( __( 'Refund made in DIBS with charge ID %1$s. Reason: %2$s', 'dibs-easy-for-woocommerce' ), $request->refundId, $reason ) );
+			$order->add_order_note( sprintf( __( 'Refund made in Nets with charge ID %1$s. Reason: %2$s', 'dibs-easy-for-woocommerce' ), $request->refundId, $reason ) );
 			return true;
 		} else {
 			return false;
@@ -242,9 +242,9 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 			}
 
 			if ( 'A2A' === $request->payment->paymentDetails->paymentType ) {
-				$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentMethod ) );
+				$order->add_order_note( sprintf( __( 'Order made in Nets with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentMethod ) );
 			} else {
-				$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
+				$order->add_order_note( sprintf( __( 'Order made in Nets with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
 			}
 			$order->payment_complete( $payment_id );
 		} else {

--- a/classes/class-dibs-order-submission-failure.php
+++ b/classes/class-dibs-order-submission-failure.php
@@ -48,7 +48,7 @@ class DIBS_OSF {
 						update_post_meta( $order_id, 'dibs_customer_card', $request->payment->paymentDetails->cardDetails->maskedPan );
 					}
 
-					$order->add_order_note( sprintf( __( 'Order made in DIBS with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
+					$order->add_order_note( sprintf( __( 'Order made in Nets with Payment ID %1$s. Payment type - %2$s.', 'dibs-easy-for-woocommerce' ), $payment_id, $request->payment->paymentDetails->paymentType ) );
 					$order->payment_complete( $payment_id );
 					WC()->cart->empty_cart();
 				}

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -38,7 +38,7 @@ class DIBS_Post_Checkout {
 			if ( 'A2A' === $payment_type ) {
 				// This is a account to account purchase (like Swish). No activation is needed/possible.
 				$dibs_payment_method = get_post_meta( $order_id, 'dibs_payment_method', true );
-				$wc_order->add_order_note( sprintf( __( 'No charge needed in DIBS system since %s is a account to account payment.', 'dibs-easy-for-woocommerce' ), $dibs_payment_method ) );
+				$wc_order->add_order_note( sprintf( __( 'No charge needed in Nets system since %s is a account to account payment.', 'dibs-easy-for-woocommerce' ), $dibs_payment_method ) );
 				return;
 			}
 
@@ -48,7 +48,7 @@ class DIBS_Post_Checkout {
 			// Error handling.
 			if ( null != $request ) {
 				if ( array_key_exists( 'chargeId', $request ) ) { // Payment success
-					$wc_order->add_order_note( sprintf( __( 'Payment made in DIBS with charge ID %s', 'dibs-easy-for-woocommerce' ), $request->chargeId ) );
+					$wc_order->add_order_note( sprintf( __( 'Payment made in Nets with charge ID %s', 'dibs-easy-for-woocommerce' ), $request->chargeId ) );
 
 					update_post_meta( $order_id, '_dibs_charge_id', $request->chargeId );
 				} elseif ( array_key_exists( 'errors', $request ) ) { // Response with errors.
@@ -63,7 +63,7 @@ class DIBS_Post_Checkout {
 					$this->charge_failed( $wc_order, true, $message );
 
 				} elseif ( array_key_exists( 'code', $request ) && '1001' == $request->code ) { // Set order as completed if order has already been charged.
-					update_post_meta( $order_id, '_dibs_charge_id', 'Payment has already been charged in DIBS' );
+					update_post_meta( $order_id, '_dibs_charge_id', 'Payment has already been charged in Nets' );
 				} else {
 					$this->charge_failed( $wc_order );
 				}
@@ -89,7 +89,7 @@ class DIBS_Post_Checkout {
 			$wc_order = wc_get_order( $order_id );
 
 			if ( null === $request ) {
-				$wc_order->add_order_note( sprintf( __( 'Order has been canceled in DIBS', 'dibs-easy-for-woocommerce' ) ) );
+				$wc_order->add_order_note( sprintf( __( 'Order has been canceled in Nets', 'dibs-easy-for-woocommerce' ) ) );
 			} else {
 				if ( array_key_exists( 'errors', $request ) ) {
 					$message = json_encode( $request->errors );
@@ -98,14 +98,14 @@ class DIBS_Post_Checkout {
 				} else {
 					$message = json_encode( $request );
 				}
-				$wc_order->add_order_note( sprintf( __( 'There was a problem canceling the order in DIBS: %s', 'dibs-easy-for-woocommerce' ), $message ) );
+				$wc_order->add_order_note( sprintf( __( 'There was a problem canceling the order in Nets: %s', 'dibs-easy-for-woocommerce' ), $message ) );
 			}
 		}
 	}
 
 	// Function to handle a failed order
-	public function charge_failed( $order, $fail = true, $message = 'Payment failed in DIBS' ) {
-		$order->add_order_note( sprintf( __( 'DIBS Error: %s', 'dibs-easy-for-woocommerce' ), $message ) );
+	public function charge_failed( $order, $fail = true, $message = 'Payment failed in Nets' ) {
+		$order->add_order_note( sprintf( __( 'Nets Error: %s', 'dibs-easy-for-woocommerce' ), $message ) );
 		if ( true === $fail ) {
 			$order->update_status( apply_filters( 'dibs_easy_failed_charge_status', 'on-hold', $order ) );
 			$order->save();

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -116,7 +116,7 @@ class DIBS_Subscriptions {
 						// $subcriptions = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'any' ) );
 						foreach ( $subcriptions as $subcription ) {
 							update_post_meta( $subcription->get_id(), '_dibs_recurring_token', $recurring_token );
-							$subcription->add_order_note( sprintf( __( 'Saved _dibs_recurring_token in subscription by externalreference request to DIBS. Recurring token: %s', 'dibs-easy-for-woocommerce' ), $response->subscriptionId ) );
+							$subcription->add_order_note( sprintf( __( 'Saved _dibs_recurring_token in subscription by externalreference request to Nets. Recurring token: %s', 'dibs-easy-for-woocommerce' ), $response->subscriptionId ) );
 						}
 						if ( 'CARD' === $response->paymentDetails->paymentType ) {
 							// Save card data in renewal order.
@@ -153,7 +153,7 @@ class DIBS_Subscriptions {
 				if ( 'Succeeded' == $recurring_order->status ) {
 					// All good. Update the renewal order with an order note and run payment_complete on all subscriptions.
 					update_post_meta( $order_id, '_dibs_date_paid', date( 'Y-m-d H:i:s' ) );
-					$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
+					$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with Nets. Nets order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
 
 					foreach ( $subscriptions as $subscription ) {
 						$subscription->payment_complete( $payment_id );
@@ -165,13 +165,13 @@ class DIBS_Subscriptions {
 				}
 			} else {
 				// Something is wrong. Run payment_failed on all subscriptions.
-				$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS. Error code: %1$s. Message: %2$s', 'dibs-easy-for-woocommerce' ), 'fel', $create_order_response->bulkId ) );
+				$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with Nets. Error code: %1$s. Message: %2$s', 'dibs-easy-for-woocommerce' ), 'fel', $create_order_response->bulkId ) );
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->payment_failed();
 				}
 			}
 		} else {
-			$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $create_order_response ) ) );
+			$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with Nets. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $create_order_response ) ) );
 			foreach ( $subscriptions as $subscription ) {
 				$subscription->payment_failed();
 			}
@@ -206,7 +206,7 @@ class DIBS_Subscriptions {
 
 				// All good. Update the renewal order with an order note and run payment_complete on all subscriptions.
 				update_post_meta( $order_id, '_dibs_date_paid', date( 'Y-m-d H:i:s' ) );
-				$order->add_order_note( sprintf( __( 'Subscription payment made with DIBS. DIBS order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
+				$order->add_order_note( sprintf( __( 'Subscription payment made with Nets. Nets order id: %s', 'dibs-easy-for-woocommerce' ), $payment_id ) );
 
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->payment_complete( $payment_id );
@@ -218,7 +218,7 @@ class DIBS_Subscriptions {
 				}
 			}
 		} else {
-			$order->add_order_note( sprintf( __( 'Subscription payment failed with DIBS during scheduled request. No paymentId found in response', 'dibs-easy-for-woocommerce' ), 'fel' ) );
+			$order->add_order_note( sprintf( __( 'Subscription payment failed with Nets during scheduled request. No paymentId found in response', 'dibs-easy-for-woocommerce' ), 'fel' ) );
 			foreach ( $subscriptions as $subscription ) {
 				$subscription->payment_failed();
 			}
@@ -231,7 +231,7 @@ class DIBS_Subscriptions {
 			<div class="order_data_column" style="clear:both; float:none; width:100%;">
 				<div class="address">
 					<?php
-						echo '<p><strong>' . __( 'DIBS recurring token' ) . ':</strong>' . get_post_meta( $order->id, '_dibs_recurring_token', true ) . '</p>';
+						echo '<p><strong>' . __( 'Nets recurring token' ) . ':</strong>' . get_post_meta( $order->id, '_dibs_recurring_token', true ) . '</p>';
 					?>
 				</div>
 				<div class="edit_address">
@@ -239,7 +239,7 @@ class DIBS_Subscriptions {
 						woocommerce_wp_text_input(
 							array(
 								'id'            => '_dibs_recurring_token',
-								'label'         => __( 'DIBS recurring token' ),
+								'label'         => __( 'Nets recurring token' ),
 								'wrapper_class' => '_billing_company_field',
 							)
 						);

--- a/classes/requests/class-dibs-requests-get-dibs-order.php
+++ b/classes/requests/class-dibs-requests-get-dibs-order.php
@@ -21,15 +21,15 @@ class DIBS_Requests_Get_DIBS_Order extends DIBS_Requests2 {
 		DIBS_Easy::log( 'DIBS GET Order response (' . $request_url . '): ' . stripslashes_deep( json_encode( $response ) ) );
 
 		if ( is_wp_error( $response ) ) {
-			$this->get_error_message( $response );
-			return 'ERROR';
+			return $this->get_error_message( $response );
+			// return 'ERROR';
 		}
 
 		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
 			return json_decode( wp_remote_retrieve_body( $response ) );
 		} else {
-			$this->get_error_message( $response );
-			return 'ERROR';
+			return $this->get_error_message( $response );
+			// return 'ERROR';
 		}
 	}
 

--- a/classes/requests/helpers/class-dibs-requests-get-checkout.php
+++ b/classes/requests/helpers/class-dibs-requests-get-checkout.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class DIBS_Requests_Checkout {
 
 	public static function get_checkout( $checkout_flow = 'embedded', $order_id = null ) {
+		$dibs_settings = get_option( 'woocommerce_dibs_easy_settings' );
+
 		$checkout = array(
 			'termsUrl' => wc_get_page_permalink( 'terms' ),
 		);
@@ -12,6 +14,9 @@ class DIBS_Requests_Checkout {
 			$checkout['url']                                     = wc_get_checkout_url();
 			$checkout['shipping']['countries']                   = array();
 			$checkout['shipping']['merchantHandlesShippingCost'] = true;
+
+			$complete_payment_button_text                                       = ( isset( $dibs_settings['complete_payment_button_text'] ) ) ? $dibs_settings['complete_payment_button_text'] : 'subscribe';
+			$checkout['appearance']['textOptions']['completePaymentButtonText'] = $complete_payment_button_text;
 		} else {
 			$order                                   = wc_get_order( $order_id );
 			$checkout['returnUrl']                   = $order->get_checkout_order_received_url();
@@ -25,7 +30,6 @@ class DIBS_Requests_Checkout {
 		if ( 'all' !== get_option( 'woocommerce_allowed_countries' ) ) {
 			$checkout['shipping']['countries'] = self::get_shipping_countries();
 		}
-		$dibs_settings          = get_option( 'woocommerce_dibs_easy_settings' );
 		$allowed_customer_types = ( isset( $dibs_settings['allowed_customer_types'] ) ) ? $dibs_settings['allowed_customer_types'] : 'B2C';
 		switch ( $allowed_customer_types ) {
 			case 'B2C':

--- a/classes/requests/helpers/class-dibs-requests-get-order-items.php
+++ b/classes/requests/helpers/class-dibs-requests-get-order-items.php
@@ -68,7 +68,7 @@ class DIBS_Requests_Get_Order_Items {
 		}
 
 		return array(
-			'reference'        => 'Shipping',
+			'reference'        => 'shipping|' . $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
 			'name'             => wc_dibs_clean_name( $shipping_method->get_method_title() ),
 			'quantity'         => '1',
 			'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),

--- a/classes/requests/helpers/class-dibs-requests-get-order-items.php
+++ b/classes/requests/helpers/class-dibs-requests-get-order-items.php
@@ -66,9 +66,14 @@ class DIBS_Requests_Get_Order_Items {
 		if ( 0 === intval( $shipping_method->get_total() ) ) {
 			$free_shipping = true;
 		}
+		if ( null !== $shipping_method->get_instance_id() ) {
+			$shipping_reference = 'shipping|' . $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id();
+		} else {
+			$shipping_reference = 'shipping|' . $shipping_method->get_method_id();
+		}
 
 		return array(
-			'reference'        => 'shipping|' . $shipping_method->get_method_id() . ':' . $shipping_method->get_instance_id(),
+			'reference'        => $shipping_reference,
 			'name'             => wc_dibs_clean_name( $shipping_method->get_method_title() ),
 			'quantity'         => '1',
 			'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.12.0
+ * Version:                 1.13.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    3.0.0
- * WC tested up to:         3.8.0
+ * WC tested up to:         3.8.1
  * Copyright:               © 2017-2019 Krokedil Produktionsbyrå AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.12.0' );
+define( 'WC_DIBS_EASY_VERSION', '1.13.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             DIBS Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
- * Version:                 1.11.1
+ * Version:                 1.12.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    3.0.0
- * WC tested up to:         3.7.0
+ * WC tested up to:         3.8.0
  * Copyright:               © 2017-2019 Krokedil Produktionsbyrå AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.11.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.12.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -5,9 +5,9 @@
  * @package WC_Dibs_Easy
  *
  * @wordpress-plugin
- * Plugin Name:             DIBS Easy for WooCommerce
+ * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
- * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">DIBS Easy</a> checkout for WooCommerce.
+ * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
  * Version:                 1.12.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
@@ -228,7 +228,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 					echo wpautop( wptexturize( __( 'Order date: ', 'dibs-easy-for-woocommerce' ) . $order_date ) );
 				}
 				if ( $payment_id ) {
-					echo wpautop( wptexturize( __( 'DIBS Payment ID: ', 'dibs-easy-for-woocommerce' ) . $payment_id ) );
+					echo wpautop( wptexturize( __( 'Nets Payment ID: ', 'dibs-easy-for-woocommerce' ) . $payment_id ) );
 				}
 				if ( $payment_method ) {
 					echo wpautop( wptexturize( __( 'Payment method: ', 'dibs-easy-for-woocommerce' ) . $payment_method ) );
@@ -241,7 +241,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 
 		public function add_error_notice_to_cart_page() {
 			if ( isset( $_GET['dibs-payment-id'] ) ) {
-				wc_print_notice( __( 'There was a problem paying with DIBS.', 'dibs-easy-for-woocommerce' ), 'error' );
+				wc_print_notice( __( 'There was a problem paying with Nets.', 'dibs-easy-for-woocommerce' ), 'error' );
 			}
 		}
 
@@ -301,7 +301,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 		 */
 		public function save_dibs_order_data( $order_id, $data ) {
 			$payment_id = $_POST['dibs_payment_id'];
-			self::log( 'Saving DIBS meta data for payment id ' . $payment_id . ' in order id ' . $order_id );
+			self::log( 'Saving Nets meta data for payment id ' . $payment_id . ' in order id ' . $order_id );
 			update_post_meta( $order_id, '_dibs_payment_id', $payment_id );
 		}
 	}

--- a/includes/dibs-checkout-functions.php
+++ b/includes/dibs-checkout-functions.php
@@ -28,7 +28,7 @@ function wc_dibs_show_snippet() {
 	} else {
 		?>
 		<ul class="woocommerce-error" role="alert">
-			<li><?php _e( 'DIBS API Error: ' . $payment_id['error_message'] ); ?></li>
+			<li><?php _e( 'Nets API Error: ' . $payment_id['error_message'] ); ?></li>
 		</ul>
 		<?php
 		// echo 'DIBS API Error: ' . $payment_id['error_message'];
@@ -127,7 +127,7 @@ function wc_dibs_get_payment_id() {
 			foreach ( $request->errors as $error ) {
 				$error_message = $error[0];
 			}
-			echo( "<script>console.log('DIBS error: " . $error_message . "');</script>" );
+			echo( "<script>console.log('Nets error: " . $error_message . "');</script>" );
 			return array(
 				'result'        => false,
 				'error_message' => $error_message,

--- a/includes/dibs-settings.php
+++ b/includes/dibs-settings.php
@@ -10,53 +10,53 @@ if ( ! defined( 'ABSPATH' ) ) {
 return apply_filters(
 	'dibs_easy_settings',
 	array(
-		'enabled'                => array(
+		'enabled'                      => array(
 			'title'   => __( 'Enable/Disable', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
 			'label'   => __( 'Enable DIBS Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
-		'title'                  => array(
+		'title'                        => array(
 			'title'       => __( 'Title', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'This is the title that the user sees on the checkout page for DIBS Easy.', 'dibs-easy-for-woocommerce' ),
 			'default'     => __( 'DIBS Easy', 'dibs-easy-for-woocommerce' ),
 		),
-		'dibs_live_key'          => array(
+		'dibs_live_key'                => array(
 			'title'       => __( 'Live Secret key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Enter your DIBS Easy live key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
-		'dibs_checkout_key'      => array(
+		'dibs_checkout_key'            => array(
 			'title'       => __( 'Live Checkout key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Enter your DIBS Easy Checkout key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
-		'dibs_test_key'          => array(
+		'dibs_test_key'                => array(
 			'title'       => __( 'Test Secret key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Enter your DIBS Easy Test key if you want to run in test mode.', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
-		'dibs_test_checkout_key' => array(
+		'dibs_test_checkout_key'       => array(
 			'title'       => __( 'Test Checkout key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Enter your DIBS Easy Test checkout key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
-		'test_mode'              => array(
+		'test_mode'                    => array(
 			'title'   => __( 'Test mode', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
 			'label'   => __( 'Enable Test mode for DIBS Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
-		'allowed_customer_types' => array(
+		'allowed_customer_types'       => array(
 			'title'       => __( 'Allowed Customer Types', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'select',
 			'options'     => array(
@@ -69,32 +69,32 @@ return apply_filters(
 			'default'     => 'B2C',
 			'desc_tip'    => false,
 		),
-		'email_text'             => array(
+		'email_text'                   => array(
 			'title'       => __( 'Email text', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'textarea',
 			'description' => __( 'This text will be added to your customers order confirmation email.', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 		),
-		'dibs_manage_orders'     => array(
+		'dibs_manage_orders'           => array(
 			'title'   => __( 'Manage orders', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
 			'label'   => __( 'Enable WooCommerce to manage orders in DIBS Easys backend', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
-		'debug_mode'             => array(
+		'debug_mode'                   => array(
 			'title'   => __( 'Debug mode', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
 			'label'   => __( 'Enable Debug mode for DIBS Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
-		'dibs_invoice_fee'       => array(
+		'dibs_invoice_fee'             => array(
 			'title'       => __( 'Invoice fee ID', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
 			'description' => sprintf( __( 'Create a hidden (simple) product that acts as the invoice fee. Enter the product <strong>ID</strong> number in this textfield. Leave blank to disable.', 'dibs-easy-for-woocommerce' ) ),
 			'default'     => '',
 			'desc_tip'    => false,
 		),
-		'checkout_flow'          => array(
+		'checkout_flow'                => array(
 			'title'       => __( 'Checkout flow', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'select',
 			'options'     => array(
@@ -103,6 +103,24 @@ return apply_filters(
 			),
 			'description' => __( 'Select how Easy should be integrated in WooCommerce. <strong>Embedded</strong> – the checkout is embedded in the WooCommerce checkout page and partially replaces the checkout form. <strong>Redirect</strong> – the customer is redirected to a payment page hosted by DIBS.', 'dibs-easy-for-woocommerce' ),
 			'default'     => 'embedded',
+			'desc_tip'    => false,
+		),
+		'complete_payment_button_text' => array(
+			'title'       => __( 'Complete payment button text', 'dibs-easy-for-woocommerce' ),
+			'type'        => 'select',
+			'options'     => array(
+				'pay'       => 'Pay',
+				'purchase'  => 'Purchase',
+				'order'     => 'Order',
+				'book'      => 'Book',
+				'reserve'   => 'Reserve',
+				'signup'    => 'Signup',
+				'subscribe' => 'Subscribe',
+				'accept'    => 'Accept',
+
+			),
+			'description' => __( 'Select the text displayed on the complete payment button. (Only applicable for subscription based payments). Translations for the selections can be found <a href="https://docs.krokedil.com/article/202-dibs-easy-subscription-support#h-H2_5" target="_blank">here.</a>', 'dibs-easy-for-woocommerce' ),
+			'default'     => 'subscribe',
 			'desc_tip'    => false,
 		),
 	)

--- a/includes/dibs-settings.php
+++ b/includes/dibs-settings.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Settings for DIBS Easy
+ * Settings for Nets Easy
  */
 
 return apply_filters(
@@ -13,47 +13,47 @@ return apply_filters(
 		'enabled'                      => array(
 			'title'   => __( 'Enable/Disable', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
-			'label'   => __( 'Enable DIBS Easy', 'dibs-easy-for-woocommerce' ),
+			'label'   => __( 'Enable Nets Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
 		'title'                        => array(
 			'title'       => __( 'Title', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
-			'description' => __( 'This is the title that the user sees on the checkout page for DIBS Easy.', 'dibs-easy-for-woocommerce' ),
-			'default'     => __( 'DIBS Easy', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'This is the title that the user sees on the checkout page for Nets Easy.', 'dibs-easy-for-woocommerce' ),
+			'default'     => __( 'Nets Easy', 'dibs-easy-for-woocommerce' ),
 		),
 		'dibs_live_key'                => array(
 			'title'       => __( 'Live Secret key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
-			'description' => __( 'Enter your DIBS Easy live key', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'Enter your Nets Easy live key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'dibs_checkout_key'            => array(
 			'title'       => __( 'Live Checkout key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
-			'description' => __( 'Enter your DIBS Easy Checkout key', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'Enter your Nets Easy Checkout key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'dibs_test_key'                => array(
 			'title'       => __( 'Test Secret key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
-			'description' => __( 'Enter your DIBS Easy Test key if you want to run in test mode.', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'Enter your Nets Easy Test key if you want to run in test mode.', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'dibs_test_checkout_key'       => array(
 			'title'       => __( 'Test Checkout key', 'dibs-easy-for-woocommerce' ),
 			'type'        => 'text',
-			'description' => __( 'Enter your DIBS Easy Test checkout key', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'Enter your Nets Easy Test checkout key', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'test_mode'                    => array(
 			'title'   => __( 'Test mode', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
-			'label'   => __( 'Enable Test mode for DIBS Easy', 'dibs-easy-for-woocommerce' ),
+			'label'   => __( 'Enable Test mode for Nets Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
 		'allowed_customer_types'       => array(
@@ -84,7 +84,7 @@ return apply_filters(
 		'debug_mode'                   => array(
 			'title'   => __( 'Debug mode', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',
-			'label'   => __( 'Enable Debug mode for DIBS Easy', 'dibs-easy-for-woocommerce' ),
+			'label'   => __( 'Enable Debug mode for Nets Easy', 'dibs-easy-for-woocommerce' ),
 			'default' => 'no',
 		),
 		'dibs_invoice_fee'             => array(
@@ -101,7 +101,7 @@ return apply_filters(
 				'embedded' => __( 'Embedded', 'dibs-easy-for-woocommerce' ),
 				'redirect' => __( 'Redirect', 'dibs-easy-for-woocommerce' ),
 			),
-			'description' => __( 'Select how Easy should be integrated in WooCommerce. <strong>Embedded</strong> – the checkout is embedded in the WooCommerce checkout page and partially replaces the checkout form. <strong>Redirect</strong> – the customer is redirected to a payment page hosted by DIBS.', 'dibs-easy-for-woocommerce' ),
+			'description' => __( 'Select how Easy should be integrated in WooCommerce. <strong>Embedded</strong> – the checkout is embedded in the WooCommerce checkout page and partially replaces the checkout form. <strong>Redirect</strong> – the customer is redirected to a payment page hosted by Nets.', 'dibs-easy-for-woocommerce' ),
 			'default'     => 'embedded',
 			'desc_tip'    => false,
 		),

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== DIBS Easy for WooCommerce ===
+=== Nets Easy for WooCommerce ===
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy
 Requires at least: 4.7
@@ -11,7 +11,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
 
 == DESCRIPTION ==
-DIBS Easy for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via DIBS new payment method Easy.
+Nets Easy for WooCommerce is a plugin that extends WooCommerce, allowing you to take payments via Nets payment method Easy.
 
 Easy is an exceptionally quick checkout for consumers. A single agreement for all payment methods. These are just some of the benefits to look forward to when choosing our new Easy payment solution for your online store.
 
@@ -24,7 +24,7 @@ https://www.youtube.com/watch?time_continue=11&v=8ipfSYPteDI
 *Easy administration* - Track sales in our user-friendly administration portal and get all payments collected in a report. It saves time in account reconsiliation and bookkeeping.
 
 = Get started =
-To get started with DIBS Easy you need to [sign up](http://www.dibs.se/easy-se) for an account.
+To get started with Nets Easy you need to [sign up](http://www.dibs.se/easy-se) for an account.
 
 More information on how to get started can be found in the [plugin documentation](http://docs.krokedil.com/documentation/dibs-easy-for-woocommerce/).
 
@@ -45,14 +45,14 @@ With a test account, you will see how the Easy administration portal works. In t
 = Which countries does this payment gateway support? =
 Available for merchants in Denmark, Sweden and Norway.
 
-= Where can I find DIBS Easy for WooCommerce documentation? =
-For help setting up and configuring DIBS Easy for WooCommerce please refer to our [documentation](http://docs.krokedil.com/documentation/dibs-easy-for-woocommerce/).
+= Where can I find Nets Easy for WooCommerce documentation? =
+For help setting up and configuring Nets Easy for WooCommerce please refer to our [documentation](http://docs.krokedil.com/documentation/dibs-easy-for-woocommerce/).
 
 = Are there any specific requirements? =
 * WooCommerce 3.0 or newer is required.
 * PHP 5.6 or higher is required.
 * A SSL Certificate is required.
-* This plugin integrates with DIBS Easy. You need an agreement with DIBS specific to the Easy platform to use this plugin.
+* This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy
 Requires at least: 4.7
-Tested up to: 5.2.3
+Tested up to: 5.2.4
 Stable tag: trunk
 Requires WooCommerce at least: 3.0
-Tested WooCommerce up to: 3.7.0
+Tested WooCommerce up to: 3.8.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -55,6 +55,12 @@ For help setting up and configuring DIBS Easy for WooCommerce please refer to ou
 * This plugin integrates with DIBS Easy. You need an agreement with DIBS specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2019.11.12    - version 1.12.0 =
+* Feature       - Add support for getting DIBS subscription ID from externalreference (support for D2 to Easy subscription transfer).
+* Tweak         - Updated subscription renewal payment logic to work with newer versions of WooCommerce Subscriptions.
+* Fix           - Rounding fix in check order totals function.
+* Fix           - Save DIBS payment method to order when it is finalized in the fallback sequence (can happen when customer not navigates back to store after Swish/Vipps purchase).
 
 = 2019.10.08    - version 1.11.1 =
 * Fix           - Remove including of file that doesn't exist in plugin. Caused error.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy
 Requires at least: 4.7
-Tested up to: 5.2.4
+Tested up to: 5.3.0
 Stable tag: trunk
 Requires WooCommerce at least: 3.0
-Tested WooCommerce up to: 3.8.0
+Tested WooCommerce up to: 3.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -55,6 +55,15 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2019.12.12    - version 1.13.0 =
+* Feature       - Added support for partial refunds.
+* Feature       - Added setting for selecting the "Complete payment" button text on subscription based payments.
+* Tweak         - Changed plugin name to Nets Easy for WooCommerce.
+* Fix           - Only update WC customer address data in JS event from DIBS if postal code or country have value or is changed.
+* Fix           - Shipping reference not being set correct when activating order.
+* Fix           - Only run function for changing to Easy payment method if no hashChange has been made (checkout process has begun). Caused an issue with Google Tag Manager for WordPress by Thomas Geiger.
+
 
 = 2019.11.12    - version 1.12.0 =
 * Feature       - Add support for getting DIBS subscription ID from externalreference (support for D2 to Easy subscription transfer).


### PR DESCRIPTION
* Feature - Added support for partial refunds.
* Feature - Added setting for selecting the "Complete payment" button text on subscription based payments.
* Tweak - Changed plugin name to Nets Easy for WooCommerce.
* Fix - Only update WC customer address data in JS event from DIBS if postal code or country have value or is changed.
* Fix - Shipping reference not being set correct when activating order.
* Fix - Only run function for changing to Easy payment method if no hashChange has been made (checkout process has begun). Caused an issue with Google Tag Manager for WordPress by Thomas Geiger.
