### PR TITLE
1.14.0

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -397,7 +397,7 @@ jQuery(function($) {
 
     // Update DIBS Easy checkout (after Woo updated_checkout)
     function update_checkout() {
-        if( checkout_initiated == 'yes' && wc_dibs_easy.paymentId == null ) {
+        if( ( checkout_initiated == 'yes' && wc_dibs_easy.paymentId == null ) || ( wc_dibs_easy.paymentId !== null && wc_dibs_easy.paymentFailed !== null ) ) {
             console.log('update checkout');
             $.ajax(
                 wc_dibs_easy.update_checkout_url,

--- a/classes/class-dibs-easy-gateway.php
+++ b/classes/class-dibs-easy-gateway.php
@@ -127,7 +127,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 				);
 				return array(
 					'result'   => 'success',
-					'redirect' => wc_get_checkout_url() . '#dibseasy=' . base64_encode( wp_json_encode( $response ) ),
+					'redirect' => '#dibseasy=' . base64_encode( wp_json_encode( $response ) ),
 				);
 			}
 		} else {

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -142,6 +142,12 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 					$paymentId = null;
 				}
 
+				if ( isset( $_GET['paymentFailed'] ) ) {
+					$paymentFailed = $_GET['paymentFailed'];
+				} else {
+					$paymentFailed = null;
+				}
+
 				if ( WC()->session->get( 'dibs_payment_id' ) ) {
 					$checkout_initiated = 'yes';
 				} else {
@@ -158,6 +164,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 					array(
 						'dibs_payment_id'                  => $dibs_payment_id,
 						'paymentId'                        => $paymentId,
+						'paymentFailed'                    => $paymentFailed,
 						'checkout_initiated'               => $checkout_initiated,
 						'standard_woo_checkout_fields'     => $standard_woo_checkout_fields,
 						'dibs_process_order_text'          => __( 'Please wait while we process your order...', 'dibs-easy-for-woocommerce' ),

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.13.1
+ * Version:                 1.14.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,8 +16,8 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    3.0.0
- * WC tested up to:         3.8.1
- * Copyright:               © 2017-2019 Krokedil Produktionsbyrå AB.
+ * WC tested up to:         3.9.1
+ * Copyright:               © 2017-2020 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.13.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.14.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.7
 Tested up to: 5.3.2
 Stable tag: trunk
 Requires WooCommerce at least: 3.0
-Tested WooCommerce up to: 3.8.1
+Tested WooCommerce up to: 3.9.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -55,6 +55,10 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2020.02.05    - version 1.14.0 =
+* Fix           - Modified redirect url set in process_payment function to improve checkout flow for purchases canceled/denied in 3DSecure window.
+* Fix           - Triggering update_checkout if GET params paymentId and PaymentFailed is set. Caused errors with subscription based payments where the nonce had to be updated.
 
 = 2020.01.22    - version 1.13.1 =
 * Tweak         - Added support for changing payment method on a subscription for customers.


### PR DESCRIPTION
* Fix - Modified redirect url set in process_payment function to improve checkout flow for purchases canceled/denied in 3DSecure window.
* Fix - Triggering update_checkout if GET params paymentId and PaymentFailed is set. Caused errors with subscription based payments where the nonce had to be updated.
