### PR TITLE
Only set web hooks if host is not local (127.0.0.1 or ::1)

### DIFF
--- a/classes/requests/helpers/class-dibs-requests-get-notifications.php
+++ b/classes/requests/helpers/class-dibs-requests-get-notifications.php
@@ -13,8 +13,8 @@ class DIBS_Requests_Notifications {
 	public static function get_web_hooks() {
 		$web_hooks = array();
 
-		// Only set web hooks if host is not local.
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && '127.0.0.1' === $_SERVER['REMOTE_ADDR'] ) {
+		// Only set web hooks if host is not local (127.0.0.1 or ::1).
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ) ) ) {
 			return $web_hooks;
 		} else {
 			$web_hooks[] = array(


### PR DESCRIPTION
Fix webhooks error on localhost over ipv6 as of the discussion on https://wordpress.org/support/topic/webhooks-error-message-on-1/