### PR TITLE
1.15.2

### DIFF
--- a/classes/requests/helpers/class-dibs-requests-get-checkout.php
+++ b/classes/requests/helpers/class-dibs-requests-get-checkout.php
@@ -13,7 +13,13 @@ class DIBS_Requests_Checkout {
 		if ( 'embedded' === $checkout_flow ) {
 			$checkout['url']                                     = wc_get_checkout_url();
 			$checkout['shipping']['countries']                   = array();
-			$checkout['shipping']['merchantHandlesShippingCost'] = true;
+
+			// If WooCommerce needs an address before calculating shipping, let's set merchantHandlesShippingCost to true.
+			if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
+				$checkout['shipping']['merchantHandlesShippingCost'] = true;
+			} else {
+				$checkout['shipping']['merchantHandlesShippingCost'] = false;
+			}
 
 			if ( 'all' !== get_option( 'woocommerce_allowed_countries' ) ) {
 				$checkout['shipping']['countries'] = self::get_shipping_countries();

--- a/classes/requests/helpers/class-dibs-requests-get-checkout.php
+++ b/classes/requests/helpers/class-dibs-requests-get-checkout.php
@@ -11,8 +11,8 @@ class DIBS_Requests_Checkout {
 			'termsUrl' => wc_get_page_permalink( 'terms' ),
 		);
 		if ( 'embedded' === $checkout_flow ) {
-			$checkout['url']                                     = wc_get_checkout_url();
-			$checkout['shipping']['countries']                   = array();
+			$checkout['url']                   = wc_get_checkout_url();
+			$checkout['shipping']['countries'] = array();
 
 			// If WooCommerce needs an address before calculating shipping, let's set merchantHandlesShippingCost to true.
 			if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
@@ -81,7 +81,7 @@ class DIBS_Requests_Checkout {
 		$consumer['email']                           = $order->get_billing_email();
 		$consumer['shippingAddress']['addressLine1'] = $order->get_billing_address_1();
 		$consumer['shippingAddress']['addressLine2'] = $order->get_billing_address_2();
-		$consumer['shippingAddress']['postalCode']   = $order->get_billing_postcode();
+		$consumer['shippingAddress']['postalCode']   = ( ! empty( $order->get_billing_postcode() ) ) ? $order->get_billing_postcode() : null;
 		$consumer['shippingAddress']['city']         = $order->get_billing_city();
 		$consumer['shippingAddress']['country']      = dibs_get_iso_3_country( $order->get_billing_country() );
 		$consumer['phoneNumber']['prefix']           = self::get_phone_prefix( $order );

--- a/classes/requests/helpers/class-dibs-requests-get-order-items.php
+++ b/classes/requests/helpers/class-dibs-requests-get-order-items.php
@@ -43,7 +43,7 @@ class DIBS_Requests_Get_Order_Items {
 
 		return array(
 			'reference'        => self::get_sku( $product, $product_id ),
-			'name'             => wc_dibs_clean_name( $product->get_name() ),
+			'name'             => wc_dibs_clean_name( $order_item->get_name() ),
 			'quantity'         => $order_item['qty'],
 			'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
 			'unitPrice'        => intval( round( ( $order_item->get_total() / $order_item['qty'] ) * 100 ) ),
@@ -121,11 +121,15 @@ class DIBS_Requests_Get_Order_Items {
 	}
 
 	public static function get_sku( $product, $product_id ) {
-		if ( get_post_meta( $product_id, '_sku', true ) !== '' ) {
-			$part_number = $product->get_sku();
+		if ( is_object( $product ) ) {
+			if ( get_post_meta( $product_id, '_sku', true ) !== '' ) {
+				$part_number = $product->get_sku();
+			} else {
+				$part_number = $product->get_id();
+			}
+			return substr( $part_number, 0, 32 );
 		} else {
-			$part_number = $product->get_id();
+			return false;
 		}
-		return substr( $part_number, 0, 32 );
 	}
 }

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.15.1
+ * Version:                 1.15.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.15.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.15.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/includes/dibs-country-converter-functions.php
+++ b/includes/dibs-country-converter-functions.php
@@ -43,5 +43,5 @@ function dibs_get_phone_prefix_for_country( $country = false ) {
 }
 
 function dibs_get_all_prefixes() {
-	return json_decode( '{"SE": "+46", "NO": "+47", "DK": "+45", "FI": "+358"}', true );
+	return include WC()->plugin_path() . '/i18n/phone.php';
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.7
 Tested up to: 5.4.0
 Stable tag: trunk
 Requires WooCommerce at least: 3.5
-Tested WooCommerce up to: 3.9.2
+Tested WooCommerce up to: 4.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -55,6 +55,13 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2020.04.30    - version 1.15.2 =
+* Tweak         - Only set merchantHandlesShippingCost to true if WooCommerce needs an address before calculate shipping (woocommerce_shipping_cost_requires_address = yes).
+* Tweak         - Set postalCode as null in request sent to Nets if we do not have a wc billing postcode.
+* Tweak         - Change product->get_name() to order_item->get_name() in requests sent to Nets.
+* Fix           - Improved phone number prefix handling. Now supports all countries that WooCommerce supports.
+* Fix           - Only try to get a sku from the product (in requests to Nets) if we have an instance of the product object. 
 
 = 2020.04.01    - version 1.15.1 =
 * Tweak         - Only register webhook if host is not local (127.0.0.1 or ::1).


### PR DESCRIPTION
* Tweak - Only set merchantHandlesShippingCost to true if WooCommerce needs an address before calculate shipping (woocommerce_shipping_cost_requires_address = yes).
* Tweak - Set postalCode as null in request sent to Nets if we do not have a wc billing postcode.
* Tweak - Change product->get_name() to order_item->get_name() in requests sent to Nets.
* Fix - Improved phone number prefix handling. Now supports all countries that WooCommerce supports.
* Fix - Only try to get a sku from the product (in requests to Nets) if we have an instance of the product object. 
