### PR TITLE
1.20.1

### DIFF
--- a/classes/class-dibs-api-callbacks.php
+++ b/classes/class-dibs-api-callbacks.php
@@ -155,6 +155,10 @@ class DIBS_Api_Callbacks {
 			$order->add_order_note( 'Payment via Nets Easy. Order status updated via API callback. Payment ID: ' . sanitize_key( $data['data']['paymentId'] ) );
 			DIBS_Easy::log( 'Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to Processing/Completed in API callback.' );
 
+			// Auto capture order if activated in settings.
+			if ( 'yes' === $auto_capture ) {
+				Nets_Easy()->order_management->dibs_order_completed( $order_id );
+			}
 		} else {
 
 			// DIBS_Easy::log('Order status not set correctly for order ' . $order->get_order_number() . ' during checkout process. Setting order status to On hold.');

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -64,7 +64,7 @@ class DIBS_Post_Checkout {
 					$this->charge_failed( $wc_order, true, $message );
 
 				} elseif ( array_key_exists( 'code', $request ) && '1001' == $request->code ) { // Set order as completed if order has already been charged.
-					update_post_meta( $order_id, '_dibs_charge_id', 'Payment has already been charged in Nets' );
+					$wc_order->add_order_note( __( 'Payment already charged in Nets', 'dibs-easy-for-woocommerce' ) );
 				} else {
 					$this->charge_failed( $wc_order );
 				}

--- a/classes/requests/class-dibs-requests-charge-subscription.php
+++ b/classes/requests/class-dibs-requests-charge-subscription.php
@@ -47,7 +47,7 @@ class DIBS_Request_Charge_Subscription extends DIBS_Requests2 {
 		$order                      = wc_get_order( $this->order_id );
 		$body                       = array();
 		$body['order']['items']     = DIBS_Requests_Get_Order_Items::get_items( $this->order_id );
-		$body['order']['amount']    = $order->get_total() * 100;
+		$body['order']['amount']    = intval( round( $order->get_total() * 100 ) );
 		$body['order']['currency']  = $order->get_currency();
 		$body['order']['reference'] = $order->get_order_number();
 

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.20.0
+ * Version:                 1.20.1
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.20.0' );
+define( 'WC_DIBS_EASY_VERSION', '1.20.1' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,12 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2020.11.23    - version 1.20.1 =
+* Tweak         - Remove unused code.
+* Fix           - Add auto capture trigger (if selected in settings) in payment created callback.
+* Fix           - Fix potential float issue in subscription renewal order request.
+* Fix           - Don't overwrite the charge id in Woo order post meta if the payment already have been charged in Nets Easy system.
+
 = 2020.11.18    - version 1.20.0 =
 * Feature       - Add compatibility support with YITH Gift Card plugin.
 * Tweak         - Don't send company name to Nets (in redirect flow) if B2C is the only allowed customer type.


### PR DESCRIPTION
* Tweak - Remove unused code.
* Fix - Add auto capture trigger (if selected in settings) in payment created callback.
* Fix - Fix potential float issue in subscription renewal order request.
* Fix - Don't overwrite the charge id in Woo order post meta if the payment already have been charged in Nets Easy system.