### PR TITLE
1.21.1

### DIFF
--- a/classes/class-dibs-ajax-calls.php
+++ b/classes/class-dibs-ajax-calls.php
@@ -202,9 +202,9 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 		if ( $order_id_match ) {
 			$order = wc_get_order( $order_id_match );
 			if ( $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
-				DIBS_Easy::log( 'Process Woo checkout triggered but _dibs_payment_id already exist in this order: ' . $order_id_match );
+				Nets_Easy()->logger->log( 'Process Woo checkout triggered but _dibs_payment_id already exist in this order: ' . $order_id_match );
 				$location = $order->get_checkout_order_received_url();
-				DIBS_Easy::log( '$location: ' . $location );
+				Nets_Easy()->logger->log( '$location: ' . $location );
 				wp_send_json_error( array( 'redirect' => $location ) );
 				wp_die();
 			}
@@ -222,7 +222,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 				$message = 'Empty response from Nets.';
 			}
 
-			DIBS_Easy::log( 'processWooCheckout triggered for Nets payment ID ' . $payment_id . ', but something went wrong. WooCommerce form not submitted. Error message: ' . wp_json_encode( $message ) );
+			Nets_Easy()->logger->log( 'processWooCheckout triggered for Nets payment ID ' . $payment_id . ', but something went wrong. WooCommerce form not submitted. Error message: ' . wp_json_encode( $message ) );
 
 			// @todo - log and/or improve this error response?
 			wp_send_json_error( $message );
@@ -237,7 +237,7 @@ class DIBS_Ajax_Calls extends WC_AJAX {
 			// Store the order data in a sesstion. We might need it if form processing in Woo fails.
 			WC()->session->set( 'dibs_order_data', $response );
 
-			DIBS_Easy::log( 'processWooCheckout triggered and checkout form about to be submitted for Nets payment ID ' . $payment_id );
+			Nets_Easy()->logger->log( 'processWooCheckout triggered and checkout form about to be submitted for Nets payment ID ' . $payment_id );
 
 			self::prepare_cart_before_form_processing( $response->payment->consumer->shippingAddress->country );
 			wp_send_json_success( $response );

--- a/classes/class-dibs-confirmation.php
+++ b/classes/class-dibs-confirmation.php
@@ -54,11 +54,11 @@ class DIBS_Confirmation {
 			$order_id = wc_get_order_id_by_order_key( sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore
 			$order    = wc_get_order( $order_id );
 
-			DIBS_Easy::log( $order_id . ': Confirmation endpoint hit for order.' );
+			Nets_Easy()->logger->log( $order_id . ': Confirmation endpoint hit for order.' );
 
 			if ( empty( $order->get_date_paid() ) ) {
 
-				DIBS_Easy::log( $order_id . ': Confirm the Nets order from the confirmation page.' );
+				Nets_Easy()->logger->log( $order_id . ': Confirm the Nets order from the confirmation page.' );
 
 				// Confirm the order.
 				wc_dibs_confirm_dibs_order( $order_id );

--- a/classes/class-dibs-logger.php
+++ b/classes/class-dibs-logger.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Logger class file.
+ *
+ * @package DIBS_Logger/Classes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Logger class.
+ */
+class DIBS_Logger {
+	/**
+	 * Log message string
+	 *
+	 * @var $log
+	 */
+	public static $log;
+
+	/**
+	 * Logs an event.
+	 *
+	 * @param string $data The data string.
+	 */
+	public static function log( $data ) {
+		$collector_settings = get_option( 'woocommerce_dibs_easy_settings' );
+		if ( 'yes' === $collector_settings['debug_mode'] ) {
+			$message = self::format_data( $data );
+			if ( empty( self::$log ) ) {
+				self::$log = new WC_Logger();
+			}
+			self::$log->add( 'nets_easy', wp_json_encode( $message ) );
+		}
+	}
+
+	/**
+	 * Formats the log data to prevent json error.
+	 *
+	 * @param string $data Json string of data.
+	 * @return array
+	 */
+	public static function format_data( $data ) {
+		if ( isset( $data['request']['body'] ) ) {
+			$request_body            = json_decode( $data['request']['body'], true );
+			$data['request']['body'] = $request_body;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Formats the log data to be logged.
+	 *
+	 * @param string $checkout_id The gateway Checkout ID.
+	 * @param string $method The method.
+	 * @param string $title The title for the log.
+	 * @param array  $request_args The request args.
+	 * @param string $request_url The request url.
+	 * @param array  $response The response.
+	 * @param string $code The status code.
+	 * @return array
+	 */
+	public static function format_log( $checkout_id, $method, $title, $request_args, $request_url, $response, $code ) {
+		// Unset the snippet to prevent issues in the response.
+		// Add logic to remove any HTML snippets from the response.
+
+		// Unset the snippet to prevent issues in the request body.
+		// Add logic to remove any HTML snippets from the request body.
+
+		return array(
+			'id'             => $checkout_id,
+			'type'           => $method,
+			'title'          => $title,
+			'request_url'    => $request_url,
+			'request'        => $request_args,
+			'response'       => array(
+				'body' => $response,
+				'code' => $code,
+			),
+			'timestamp'      => date( 'Y-m-d H:i:s' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
+			'stack'          => self::get_stack(),
+			'plugin_version' => WC_DIBS_EASY_VERSION,
+		);
+	}
+
+	/**
+	 * Gets the stack for the request.
+	 *
+	 * @return array
+	 */
+	public static function get_stack() {
+		$debug_data = debug_backtrace(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions -- Data is not used for display.
+		$stack      = array();
+		foreach ( $debug_data as $data ) {
+			$extra_data = '';
+			if ( ! in_array( $data['function'], array( 'get_stack', 'format_log' ), true ) ) {
+				if ( in_array( $data['function'], array( 'do_action', 'apply_filters' ), true ) ) {
+					if ( isset( $data['object'] ) ) {
+						$priority   = $data['object']->current_priority();
+						$name       = key( $data['object']->current() );
+						$extra_data = $name . ' : ' . $priority;
+					}
+				}
+			}
+			$stack[] = $data['function'] . $extra_data;
+		}
+		return $stack;
+	}
+}

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -94,7 +94,7 @@ class DIBS_Post_Checkout {
 					$this->charge_failed( $wc_order, true, $message );
 
 				} elseif ( array_key_exists( 'code', $request ) && '1001' === $request->code ) { // Set order as completed if order has already been charged.
-					$wc_order->add_order_note( __( 'Payment already charged in Nets', 'dibs-easy-for-woocommerce' ) );
+					$wc_order->add_order_note( sprintf( __( 'Nets error message: %s', 'dibs-easy-for-woocommerce' ), $request->message ) ); // phpcs:ignore
 				} else {
 					$this->charge_failed( $wc_order );
 				}
@@ -156,4 +156,3 @@ class DIBS_Post_Checkout {
 		}
 	}
 }
-$dibs_post_checkout = new DIBS_Post_Checkout();

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -65,6 +65,13 @@ class DIBS_Post_Checkout {
 				return;
 			}
 
+			// Bail if order total is 0. Can happen for 0 value initial subscription orders.
+			if ( round( 0, 2 ) === round( $wc_order->get_total(), 2 ) ) {
+				/* Translators: WC order total for the order. */
+				$wc_order->add_order_note( sprintf( __( 'No charge needed in Nets system since the order total is %s.', 'dibs-easy-for-woocommerce' ), $wc_order->get_total() ) );
+				return;
+			}
+
 			$request = new DIBS_Requests_Activate_Order( $order_id );
 			$request = json_decode( $request->request() );
 

--- a/classes/class-dibs-post-checkout.php
+++ b/classes/class-dibs-post-checkout.php
@@ -94,6 +94,7 @@ class DIBS_Post_Checkout {
 					$this->charge_failed( $wc_order, true, $message );
 
 				} elseif ( array_key_exists( 'code', $request ) && '1001' === $request->code ) { // Set order as completed if order has already been charged.
+					// @todo - set status to on hold if WC order total and Nets order total don't match.
 					$wc_order->add_order_note( sprintf( __( 'Nets error message: %s', 'dibs-easy-for-woocommerce' ), $request->message ) ); // phpcs:ignore
 				} else {
 					$this->charge_failed( $wc_order );

--- a/classes/requests/class-dibs-requests-activate-order.php
+++ b/classes/requests/class-dibs-requests-activate-order.php
@@ -39,10 +39,16 @@ class DIBS_Requests_Activate_Order extends DIBS_Requests2 {
 	 */
 	public function request() {
 
-		$order       = wc_get_order( $this->order_id );
-		$payment_id  = $order->get_transaction_id();
-		$request_url = $this->endpoint . 'payments/' . $payment_id . '/charges';
-		$response    = wp_remote_request( $request_url, $this->get_request_args() );
+		$order        = wc_get_order( $this->order_id );
+		$payment_id   = $order->get_transaction_id();
+		$request_url  = $this->endpoint . 'payments/' . $payment_id . '/charges';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
+
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $payment_id, 'POST', 'Nets activate order', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
 
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
@@ -70,7 +76,6 @@ class DIBS_Requests_Activate_Order extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Activate Order request args: ' . wp_json_encode( $request_args ) );
 		return apply_filters( 'dibs_easy_activate_order_args', $request_args );
 	}
 

--- a/classes/requests/class-dibs-requests-cancel-order.php
+++ b/classes/requests/class-dibs-requests-cancel-order.php
@@ -38,11 +38,16 @@ class DIBS_Requests_Cancel_Order extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$payment_id = get_post_meta( $this->order_id, '_dibs_payment_id', true );
+		$payment_id   = get_post_meta( $this->order_id, '_dibs_payment_id', true );
+		$request_url  = $this->endpoint . 'payments/' . $payment_id . '/cancels';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
 
-		$request_url = $this->endpoint . 'payments/' . $payment_id . '/cancels';
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $payment_id, 'POST', 'Nets cancel order', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
 
-		$response = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
 			return 'ERROR';
@@ -69,7 +74,6 @@ class DIBS_Requests_Cancel_Order extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Cancel Order request args: ' . wp_json_encode( $request_args ) );
 		return apply_filters( 'dibs_easy_cancel_order_args', $request_args );
 	}
 

--- a/classes/requests/class-dibs-requests-create-dibs-order.php
+++ b/classes/requests/class-dibs-requests-create-dibs-order.php
@@ -35,9 +35,15 @@ class DIBS_Requests_Create_DIBS_Order extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$request_url = $this->endpoint . 'payments';
-		$response    = wp_remote_request( $request_url, $this->get_request_args() );
-		DIBS_Easy::log( 'DIBS Create Order request response: ' . stripslashes_deep( wp_json_encode( $response ) ) );
+		$request_url  = $this->endpoint . 'payments';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
+
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( '', 'POST', 'Nets initialize payment', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
+
 		if ( is_wp_error( $response ) ) {
 			return $this->get_error_message( $response );
 		}
@@ -62,7 +68,6 @@ class DIBS_Requests_Create_DIBS_Order extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Create Order request args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
 		return $request_args;
 	}
 

--- a/classes/requests/class-dibs-requests-get-dibs-order.php
+++ b/classes/requests/class-dibs-requests-get-dibs-order.php
@@ -46,11 +46,14 @@ class DIBS_Requests_Get_DIBS_Order extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$request_url = $this->endpoint . 'payments/' . $this->payment_id;
+		$request_url  = $this->endpoint . 'payments/' . $this->payment_id;
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
 
-		$response = wp_remote_request( $request_url, $this->get_request_args() );
-
-		DIBS_Easy::log( 'DIBS GET Order response (' . $request_url . '): ' . stripslashes_deep( wp_json_encode( $response ) ) );
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $this->payment_id, 'GET', 'Nets get checkout', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
 
 		if ( is_wp_error( $response ) ) {
 			return $this->get_error_message( $response );
@@ -75,8 +78,6 @@ class DIBS_Requests_Get_DIBS_Order extends DIBS_Requests2 {
 			'method'     => 'GET',
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Get Order request args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
-
 		return $request_args;
 	}
 }

--- a/classes/requests/class-dibs-requests-get-subscription-bulk-charge-id.php
+++ b/classes/requests/class-dibs-requests-get-subscription-bulk-charge-id.php
@@ -16,7 +16,7 @@ class DIBS_Request_Get_Subscription_Bulk_Id extends DIBS_Requests2 {
 	public function request() {
 		$request_url  = $this->endpoint . 'subscriptions/charges/' . $this->bulk_id;
 		$request_args = $this->get_request_args();
-		DIBS_Easy::log( 'DIBS Get Subscription Bulk Charge ID args (' . $request_url . '): ' . stripslashes_deep( json_encode( $request_args ) ) );
+		Nets_Easy()->logger->log( 'DIBS Get Subscription Bulk Charge ID args (' . $request_url . '): ' . stripslashes_deep( json_encode( $request_args ) ) );
 
 		$response = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $response ) ) {
@@ -25,7 +25,7 @@ class DIBS_Request_Get_Subscription_Bulk_Id extends DIBS_Requests2 {
 		}
 
 		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
-			DIBS_Easy::log( 'DIBS  Get Subscription Bulk Charge ID response: ' . stripslashes_deep( json_encode( $response ) ) );
+			Nets_Easy()->logger->log( 'DIBS  Get Subscription Bulk Charge ID response: ' . stripslashes_deep( json_encode( $response ) ) );
 			return json_decode( wp_remote_retrieve_body( $response ) );
 		} else {
 			return $this->get_error_message( $response );

--- a/classes/requests/class-dibs-requests-get-subscription-by-external-reference.php
+++ b/classes/requests/class-dibs-requests-get-subscription-by-external-reference.php
@@ -48,7 +48,7 @@ class DIBS_Request_Get_Subscription_By_External_Reference extends DIBS_Requests2
 	public function request() {
 		$request_url  = $this->endpoint . 'subscriptions?externalreference=' . $this->external_reference;
 		$request_args = $this->get_request_args();
-		DIBS_Easy::log( 'DIBS Get Subscription by externalreference args (' . $request_url . '): ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
+		Nets_Easy()->logger->log( 'DIBS Get Subscription by externalreference args (' . $request_url . '): ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
 
 		$response = wp_remote_request( $request_url, $this->get_request_args() );
 		if ( is_wp_error( $response ) ) {
@@ -56,7 +56,7 @@ class DIBS_Request_Get_Subscription_By_External_Reference extends DIBS_Requests2
 		}
 
 		if ( $response['response']['code'] >= 200 && $response['response']['code'] <= 299 ) {
-			DIBS_Easy::log( 'DIBS Get Subscription by externalreference response: ' . stripslashes_deep( wp_json_encode( $response ) ) );
+			Nets_Easy()->logger->log( 'DIBS Get Subscription by externalreference response: ' . stripslashes_deep( wp_json_encode( $response ) ) );
 			return json_decode( wp_remote_retrieve_body( $response ) );
 		} else {
 			return $this->get_error_message( $response );

--- a/classes/requests/class-dibs-requests-get-subscription.php
+++ b/classes/requests/class-dibs-requests-get-subscription.php
@@ -46,11 +46,14 @@ class DIBS_Requests_Get_Subscription extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$request_url = $this->endpoint . 'subscriptions/' . $this->subscription_id;
+		$request_url  = $this->endpoint . 'subscriptions/' . $this->subscription_id;
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
 
-		$response = wp_remote_request( $request_url, $this->get_request_args() );
-
-		DIBS_Easy::log( 'DIBS GET Subscription response (' . $request_url . '): ' . stripslashes_deep( wp_json_encode( $response ) ) );
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $this->subscription_id, 'GET', 'Nets get subscription', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
 
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
@@ -77,8 +80,6 @@ class DIBS_Requests_Get_Subscription extends DIBS_Requests2 {
 			'method'     => 'GET',
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Get Subscription request args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
-
 		return $request_args;
 	}
 }

--- a/classes/requests/class-dibs-requests-refund-order.php
+++ b/classes/requests/class-dibs-requests-refund-order.php
@@ -47,6 +47,12 @@ class DIBS_Request_Refund_Order extends DIBS_Requests2 {
 	public function request() {
 		$charge_id = get_post_meta( $this->order_id, '_dibs_charge_id', true );
 
+		if ( empty( $purchase_id ) ) {
+			$order = wc_get_order( $this->order_id );
+			$order->add_order_note( __( 'Nets Easy order could not be refunded. Missing Charge id.', 'dibs-easy-for-woocommerce' ) );
+			return;
+		}
+
 		$request_url  = $this->endpoint . 'charges/' . $charge_id . '/refunds';
 		$request_args = $this->get_request_args();
 		$response     = wp_remote_request( $request_url, $request_args );

--- a/classes/requests/class-dibs-requests-refund-order.php
+++ b/classes/requests/class-dibs-requests-refund-order.php
@@ -47,9 +47,15 @@ class DIBS_Request_Refund_Order extends DIBS_Requests2 {
 	public function request() {
 		$charge_id = get_post_meta( $this->order_id, '_dibs_charge_id', true );
 
-		$request_url = $this->endpoint . 'charges/' . $charge_id . '/refunds';
+		$request_url  = $this->endpoint . 'charges/' . $charge_id . '/refunds';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
 
-		$response = wp_remote_request( $request_url, $this->get_request_args() );
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $charge_id, 'POST', 'Nets refund order', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
+
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
 			return 'ERROR';
@@ -76,7 +82,6 @@ class DIBS_Request_Refund_Order extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Refund Order request args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
 		return apply_filters( 'dibs_easy_refund_order_args', $request_args );
 	}
 

--- a/classes/requests/class-dibs-requests-update-dibs-order-reference.php
+++ b/classes/requests/class-dibs-requests-update-dibs-order-reference.php
@@ -49,10 +49,15 @@ class DIBS_Requests_Update_DIBS_Order_Reference extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$request_url = $this->endpoint . 'payments/' . $this->payment_id . '/referenceinformation';
+		$request_url  = $this->endpoint . 'payments/' . $this->payment_id . '/referenceinformation';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $request_args );
+		$code         = wp_remote_retrieve_response_code( $response );
 
-		$response = wp_remote_request( $request_url, $this->get_request_args() );
-		DIBS_Easy::log( 'DIBS Update Order reference response (' . $request_url . '): ' . stripslashes_deep( wp_json_encode( $response ) ) );
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $this->payment_id, 'PUT', 'Nets update reference', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
+
 		if ( is_wp_error( $response ) ) {
 			$this->get_error_message( $response );
 			return 'ERROR';
@@ -79,8 +84,6 @@ class DIBS_Requests_Update_DIBS_Order_Reference extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Update Order reference args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
-
 		return $request_args;
 	}
 

--- a/classes/requests/class-dibs-requests-update-dibs-order.php
+++ b/classes/requests/class-dibs-requests-update-dibs-order.php
@@ -37,8 +37,15 @@ class DIBS_Requests_Update_DIBS_Order extends DIBS_Requests2 {
 	 * @return mixed
 	 */
 	public function request() {
-		$request_url = $this->endpoint . 'payments/' . $this->payment_id . '/orderitems';
-		$response    = wp_remote_request( $request_url, $this->get_request_args() );
+		$request_url  = $this->endpoint . 'payments/' . $this->payment_id . '/orderitems';
+		$request_args = $this->get_request_args();
+		$response     = wp_remote_request( $request_url, $this->get_request_args() );
+		$code         = wp_remote_retrieve_response_code( $response );
+
+		// Log the request.
+		$log = Nets_Easy()->logger->format_log( $this->payment_id, 'PUT', 'Nets update cart', $request_args, $request_url, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		Nets_Easy()->logger->log( $log );
+
 		if ( is_wp_error( $response ) ) {
 			return $this->get_error_message( $response );
 		}
@@ -63,8 +70,6 @@ class DIBS_Requests_Update_DIBS_Order extends DIBS_Requests2 {
 			'body'       => wp_json_encode( $this->request_body() ),
 			'timeout'    => apply_filters( 'nets_easy_set_timeout', 10 ),
 		);
-		DIBS_Easy::log( 'DIBS Update Order request args: ' . stripslashes_deep( wp_json_encode( $request_args ) ) );
-
 		return $request_args;
 	}
 

--- a/classes/requests/class-dibs-requests.php
+++ b/classes/requests/class-dibs-requests.php
@@ -92,7 +92,7 @@ class DIBS_Requests2 {
 		$errors = new WP_Error();
 		$errors->add( 'dibs_easy', $response_body );
 
-		DIBS_Easy::log( 'DIBS Error Response: ' . stripslashes_deep( wp_json_encode( $response_body ) ) );
+		Nets_Easy()->logger->log( 'DIBS Error Response: ' . stripslashes_deep( wp_json_encode( $response_body ) ) );
 		return $errors;
 	}
 }

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -49,13 +49,6 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 		protected static $instance;
 
 		/**
-		 * Reference to logging class.
-		 *
-		 * @var $log
-		 */
-		public static $log = '';
-
-		/**
 		 * Reference to dibs_settings.
 		 *
 		 * @var $dibs_settings
@@ -120,6 +113,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 			include_once plugin_basename( 'classes/class-dibs-admin-notices.php' );
 			include_once plugin_basename( 'classes/class-dibs-api-callbacks.php' );
 			include_once plugin_basename( 'classes/class-dibs-confirmation.php' );
+			include_once plugin_basename( 'classes/class-dibs-logger.php' );
 
 			include_once plugin_basename( 'classes/class-dibs-subscriptions.php' );
 
@@ -166,6 +160,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 
 			// Set variables for shorthand access to classes.
 			$this->order_management = new DIBS_Post_Checkout();
+			$this->logger           = new DIBS_Logger();
 
 		}
 
@@ -345,21 +340,6 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 		}
 
 		/**
-		 * Log function. Log messages to file.
-		 *
-		 * @param string $message Data to log.
-		 */
-		public static function log( $message ) {
-			$dibs_settings = get_option( 'woocommerce_dibs_easy_settings' );
-			if ( 'yes' === $dibs_settings['debug_mode'] ) {
-				if ( empty( self::$log ) ) {
-					self::$log = new WC_Logger();
-				}
-				self::$log->add( 'dibs_easy', $message );
-			}
-		}
-
-		/**
 		 * Saves DIBS data to WooCommerce order as meta field.
 		 *
 		 * @param string $order_id WooCommerce order id.
@@ -367,7 +347,7 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 		 */
 		public function save_dibs_order_data( $order_id, $data ) {
 			$payment_id = filter_input( INPUT_POST, 'dibs_payment_id', FILTER_SANITIZE_STRING );
-			self::log( 'Saving Nets meta data for payment id ' . $payment_id . ' in order id ' . $order_id );
+			Nets_Easy()->logger->log( 'Saving Nets meta data for payment id ' . $payment_id . ' in order id ' . $order_id );
 			update_post_meta( $order_id, '_dibs_payment_id', $payment_id );
 		}
 	}

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,15 +8,15 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.21.0
+ * Version:                 1.21.1
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
  * Developer URI:           https://krokedil.se/
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
- * WC requires at least:    3.8.0
- * WC tested up to:         4.9.2
+ * WC requires at least:    4.0.0
+ * WC tested up to:         5.0.0
  * Copyright:               © 2017-2021 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.21.0' );
+define( 'WC_DIBS_EASY_VERSION', '1.21.1' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy, nets
 Requires at least: 4.7
-Tested up to: 5.6
-Requires PHP: 5.6.1
-WC requires at least: 3.8.0
-WC tested up to: 4.9.2
+Tested up to: 5.6.2
+Requires PHP: 5.6
+WC requires at least: 4.0.0
+WC tested up to: 5.0.0
 Stable tag: trunk
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -56,6 +56,14 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2021.02.24    - version 1.21.1 =
+* Tweak         - Improved logging. Move logging logic to separate class.
+* Tweak         - Log file now named nets_easy in WooCommerce admin.
+* Tweak         - Display the returned error message in order note if error code 1001 is returned in charge request.
+* Fix           - Don't trigger a charge/activation request to Nets if WC order total is 0.
+* Fix           - Add order note if missing charge id in refund request.
+* Fix           - Don't try to instanciate Post_Checkout class twice.
 
 = 2021.02.05    - version 1.21.0 =
 * Feature       - Add Merchant Number setting. Only required if you are a partner and initiating the checkout with your partner keys.

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,7 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * Tweak         - Display the returned error message in order note if error code 1001 is returned in charge request.
 * Fix           - Don't trigger a charge/activation request to Nets if WC order total is 0.
 * Fix           - Add order note if missing charge id in refund request.
-* Fix           - Don't try to instanciate Post_Checkout class twice.
+* Fix           - Don't try to instantiate Post_Checkout class twice.
 
 = 2021.02.05    - version 1.21.0 =
 * Feature       - Add Merchant Number setting. Only required if you are a partner and initiating the checkout with your partner keys.


### PR DESCRIPTION
* Tweak - Improved logging. Move logging logic to separate class.
* Tweak - Log file now named nets_easy in WooCommerce admin.
* Tweak - Display the returned error message in order note if error code 1001 is returned in charge request.
* Fix - Don't trigger a charge/activation request to Nets if WC order total is 0.
* Fix - Add order note if missing charge id in refund request.
* Fix - Don't try to instantiate Post_Checkout class twice.