### PR TITLE
1.22.0

### DIFF
--- a/classes/class-dibs-api-callbacks.php
+++ b/classes/class-dibs-api-callbacks.php
@@ -85,7 +85,8 @@ class DIBS_Api_Callbacks {
 			Nets_Easy()->logger->log( 'No coresponding order ID was found for Payment ID ' . $data['data']['paymentId'] );
 			// Backup order creation.
 			if ( ! empty( $data['data']['paymentId'] ) ) {
-				$this->backup_order_creation( $data );
+				// @todo - remove all reference to backup order creation process.
+				// $this->backup_order_creation( $data );
 			}
 		}
 	}

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/dibs/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.21.2
+ * Version:                 1.22.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.21.2' );
+define( 'WC_DIBS_EASY_VERSION', '1.22.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy, nets
 Requires at least: 4.7
-Tested up to: 5.6.2
+Tested up to: 5.7
 Requires PHP: 5.6
 WC requires at least: 4.0.0
 WC tested up to: 5.0.0
@@ -56,6 +56,10 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2021.03.09    - version 1.22.0 =
+* Tweak         - Remove backup order creation feature. WooCommerce order should always be created on pay-initialized JS event.
+* Fix           - Modify filter woocommerce_order_needs_payment so recurring token is saved in WooCommerce subscription even if initial order contain a recurring coupon that results in a 0 value order.
 
 = 2021.03.05    - version 1.21.2 =
 * Tweak         - Updated url to WooCommerce.com docs about configuring terms page.


### PR DESCRIPTION
* Tweak - Remove backup order creation feature. WooCommerce order should always be created on pay-initialized JS event.
* Fix - Modify filter _woocommerce_order_needs_payment_ so recurring token is saved in WooCommerce subscription even if initial order contain a recurring coupon that results in a 0 value order.