### PR TITLE
Version 1.23.2

### DIFF
--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -51,6 +51,9 @@ class DIBS_Subscriptions {
 				'endDate'  => gmdate( 'Y-m-d\TH:i', strtotime( '+5 year' ) ),
 				'interval' => 0,
 			);
+
+			$complete_payment_button_text = ( isset( $dibs_settings['complete_payment_button_text'] ) ) ? $dibs_settings['complete_payment_button_text'] : 'subscribe';
+			$request_args['appearance']['textOptions']['completePaymentButtonText'] = $complete_payment_button_text;
 		}
 
 		// Checks if this is a DIBS subscription payment method change.

--- a/classes/requests/helpers/class-dibs-requests-get-checkout.php
+++ b/classes/requests/helpers/class-dibs-requests-get-checkout.php
@@ -44,9 +44,6 @@ class DIBS_Requests_Checkout {
 			if ( 'all' !== get_option( 'woocommerce_allowed_countries' ) ) {
 				$checkout['shipping']['countries'] = self::get_shipping_countries();
 			}
-
-			$complete_payment_button_text                                       = ( isset( $dibs_settings['complete_payment_button_text'] ) ) ? $dibs_settings['complete_payment_button_text'] : 'subscribe';
-			$checkout['appearance']['textOptions']['completePaymentButtonText'] = $complete_payment_button_text;
 		} else {
 			$order                                   = wc_get_order( $order_id );
 			$checkout['returnUrl']                   = add_query_arg( 'easy_confirm', 'yes', $order->get_checkout_order_received_url() );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.23.0
+ * Version:                 1.23.1
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.23.0' );
+define( 'WC_DIBS_EASY_VERSION', '1.23.1' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.22.0
+ * Version:                 1.23.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    4.0.0
- * WC tested up to:         5.0.0
+ * WC tested up to:         5.2.2
  * Copyright:               © 2017-2021 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.22.1' );
+define( 'WC_DIBS_EASY_VERSION', '1.23.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, easy, nets
 Requires at least: 4.7
-Tested up to: 5.7
+Tested up to: 5.7.1
 Requires PHP: 5.6
 WC requires at least: 4.0.0
-WC tested up to: 5.0.0
+WC tested up to: 5.2.2
 Stable tag: trunk
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -56,6 +56,14 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Easy platform to use this plugin.
 
 == CHANGELOG ==
+
+= 2021.05.03    - version 1.23.0 =
+* Feature       - Updated countries supported by Nets (https://tech.dibspayment.com/easy/api/datastring-parameters).
+* Tweak         - Change DIBS to Nets in readme and settings.
+* Tweak         - Remove old/unused code related to backup order creation.
+* Tweak         - Remove code for saving order note field & extra checkout field data in session storage. Not needed in current embedded checkout flow.
+* Fix           - Improved logic for handling payment processing on API callback. Fixes issues with Swish/Vipps payments where customer never returns to store/browser after completed payment. 
+* Fix           - Improve function get_order_id_from_payment_id. Don't try to make a query to db if missing payment_id.
 
 = 2021.03.09    - version 1.22.0 =
 * Tweak         - Remove backup order creation feature. WooCommerce order should always be created on pay-initialized JS event.

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,9 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2021.05.10    - version 1.23.1 =
+* Tweak         - Only send information about completePaymentButtonText if cart contain subscription. Solves issue where "Subscribe" text could be displayed in pay button even for regular purchases.
+
 = 2021.05.03    - version 1.23.0 =
 * Feature       - Updated countries supported by Nets (https://tech.dibspayment.com/easy/api/datastring-parameters).
 * Tweak         - Change DIBS to Nets in readme and settings.


### PR DESCRIPTION
* Tweak - Use Action scheduler instead of WP cron for queuing payment created webhook handling. This is a more reliable solution.
* Tweak - Only try to send the customer data to Nets that actually exist in WooCommerce order. Improves redirect flow where the store doesn't enable full address collecting. 