### PR TITLE
Version 1.23.4

### DIFF
--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -343,6 +343,11 @@ class DIBS_Subscriptions {
 			return $wc_result;
 		}
 
+		// Only change in checkout.
+		if ( ! is_checkout() ) {
+			return $wc_result;
+		}
+
 		return true;
 	}
 

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 1.23.3
+ * Version:                 1.23.4
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '1.23.3' );
+define( 'WC_DIBS_EASY_VERSION', '1.23.4' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,9 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 
 == CHANGELOG ==
 
+= 2021.06.29    - version 1.23.4 =
+* Fix           - Improvement in woocommerce_order_needs_payment filter. Could cause Pay for order button being visible on My account pages even for paid orders.
+
 = 2021.06.28    - version 1.23.3 =
 * Fix           - Change array_key_exists to isset to better handle PHP 8 compatibility.
 * Fix           - Create new payment session if currency changes during an ongoing session in checkout.


### PR DESCRIPTION
* Fix - Improvement in woocommerce_order_needs_payment filter. Could cause Pay for order button being visible on My account pages even for paid orders.