### PR TITLE
Do not set web hooks if Host is localhost

### DIFF
--- a/classes/requests/helpers/class-dibs-requests-get-notifications.php
+++ b/classes/requests/helpers/class-dibs-requests-get-notifications.php
@@ -36,7 +36,7 @@ class DIBS_Requests_Notifications {
 		$web_hooks = array();
 
 		// Only set web hooks if host is not local (127.0.0.1 or ::1).
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) ) {
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) || isset( $_SERVER['HTTP_HOST'] ) && 'localhost' === substr( $_SERVER['HTTP_HOST'], 0, 9 ) ) {
 			return $web_hooks;
 		} else {
 			$web_hooks[] = array(


### PR DESCRIPTION
Docker does not use the default localhost IP address. One way to get around this it to check if the Host field is set to localhost.

If the host is not using the default 80 port, the used port number will be set in, and part of, the Host field which is why we check for the substring localhost.