### PR TITLE
Check if session exists before access

### DIFF
--- a/includes/dibs-checkout-functions.php
+++ b/includes/dibs-checkout-functions.php
@@ -283,7 +283,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
  * @return void
  */
 function wc_dibs_save_shipping_reference_to_order( $order_id ) {
-	if ( method_exists( WC()->session, 'get' ) ) {
+	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
 		$packages        = WC()->shipping->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];


### PR DESCRIPTION
The Session object may not always exist.

```
2022-03-01T08:09:00+00:00 CRITICAL Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /home/site/public_html/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php:286
Stack trace:
#0 /home/site/public_html/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php(286): method_exists(NULL, 'get')
#1 /home/site/public_html/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php(232): wc_dibs_save_shipping_reference_to_order(155977)
#2 /home/site/public_html/wp-content/plugins/dibs-easy-for-woocommerce/classes/class-dibs-api-callbacks.php(98): wc_dibs_confirm_dibs_order(155977)
#3 /home/site/public_html/wp-includes/class-wp-hook.php(307): DIBS_Api_Callbacks->execute_dibs_payment_created_callback('01060000621dd28...', '155977', 104900)
#4 /home/site/public_html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#5 /home/site/public_html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#6 /home/site/public_html/wp-content/plugins/woocommerce/packages/action-scheduler/classes/actions/ActionScheduler_Action.php(22): do_action_ref_array('dibs_payment_cr...', Array)
#7 /home/site/public_html/wp-content/plugins/woocommerce/packages/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php(65): ActionScheduler_Action->execute()
#8 /home/site/public_html/wp-content/plugins/woocommerce/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php(162): ActionScheduler_Abstract_QueueRunner->process_action(171535, 'WP Cron')
#9 /home/site/public_html/wp-content/plugins/woocommerce/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php(132): ActionScheduler_QueueRunner->do_batch(25, 'WP Cron')
#10 /home/site/public_html/wp-includes/class-wp-hook.php(307): ActionScheduler_QueueRunner->run('WP Cron')
#11 /home/site/public_html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#12 /home/site/public_html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#13 /home/site/public_html/wp-cron.php(138): do_action_ref_array('action_schedule...', Array)
#14 {main}
  thrown i /home/site/public_html/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php på linje 286
```