### PR TITLE
Remove argnum from format specifier

### DIFF
--- a/classes/class-dibs-easy-gateway.php
+++ b/classes/class-dibs-easy-gateway.php
@@ -206,7 +206,7 @@ class DIBS_Easy_Gateway extends WC_Payment_Gateway {
 
 		if ( array_key_exists( 'refundId', $request ) ) { // Payment success
 			// Translators: Nets refund ID.
-			$order->add_order_note( sprintf( __( 'Refund made in Nets Easy with refund ID %1$s. Reason: %2$s', 'dibs-easy-for-woocommerce' ), $request['refundId'], $reason ) ); // phpcs:ignore
+			$order->add_order_note( sprintf( __( 'Refund made in Nets Easy with refund ID %s. Reason: %s', 'dibs-easy-for-woocommerce' ), $request['refundId'], $reason ) ); // phpcs:ignore
 			return true;
 		} else {
 			return false;

--- a/classes/class-dibs-subscriptions.php
+++ b/classes/class-dibs-subscriptions.php
@@ -261,14 +261,14 @@ class DIBS_Subscriptions {
 			update_post_meta( $order_id, '_dibs_date_paid', gmdate( 'Y-m-d H:i:s' ) );
 			update_post_meta( $order_id, '_dibs_charge_id', $create_order_response->chargeId ); // phpcs:ignore
 			/* Translators: Nets Payment ID & Charge ID. */
-			$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with Nets. Payment ID: %1$s. Charge ID %2$s.', 'dibs-easy-for-woocommerce' ), $create_order_response->paymentId, $create_order_response->chargeId ) ); // phpcs:ignore
+			$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with Nets. Payment ID: %s. Charge ID %s.', 'dibs-easy-for-woocommerce' ), $create_order_response->paymentId, $create_order_response->chargeId ) ); // phpcs:ignore
 
 			foreach ( $subscriptions as $subscription ) {
 				$subscription->payment_complete( $create_order_response->paymentId ); // phpcs:ignore
 			}
 		} else {
 			/* Translators: Request response from Nets. */
-			$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with Nets. Error message: %1$s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $create_order_response ) ) );
+			$renewal_order->add_order_note( sprintf( __( 'Subscription payment failed with Nets. Error message: %s.', 'dibs-easy-for-woocommerce' ), wp_json_encode( $create_order_response ) ) );
 			foreach ( $subscriptions as $subscription ) {
 				$subscription->payment_failed();
 			}

--- a/languages/dibs-easy-for-woocommerce-sv_SE.po
+++ b/languages/dibs-easy-for-woocommerce-sv_SE.po
@@ -91,15 +91,15 @@ msgstr ""
 
 #: classes/class-dibs-subscriptions.php:235
 #, php-format
-msgid "Subscription payment made with Nets. Payment ID: %1$s. Charge ID %2$s."
+msgid "Subscription payment made with Nets. Payment ID: %s. Charge ID %s."
 msgstr ""
-"Prenumerationsbetalning gjord hos Nets. Betalnings ID: %1$s. Debiterings ID "
-"%2$s."
+"Prenumerationsbetalning gjord hos Nets. Betalnings ID: %s. Debiterings ID "
+"%s."
 
 #: classes/class-dibs-subscriptions.php:241
 #, php-format
-msgid "Subscription payment failed with Nets. Error message: %1$s."
-msgstr "Prenumerationsbetalning misslyckades hos Nets. Felmeddelande: %1$s."
+msgid "Subscription payment failed with Nets. Error message: %s."
+msgstr "Prenumerationsbetalning misslyckades hos Nets. Felmeddelande: %s."
 
 #: classes/class-dibs-subscriptions.php:276
 #, php-format
@@ -109,7 +109,7 @@ msgstr "Prenumerationsbetalning genomförd hos Nets. Nets order id: %s"
 #: classes/class-dibs-subscriptions.php:282
 #, php-format
 msgid ""
-"Payment status not correct for subscription. Status: %1$s. Message: %2$s"
+"Payment status not correct for subscription. Status: %s. Message: %s"
 msgstr ""
 
 #: classes/class-dibs-subscriptions.php:288
@@ -120,7 +120,7 @@ msgstr ""
 
 #: classes/class-dibs-api-callbacks.php:148
 #, php-format
-msgid "Failed trying to receive the order from Nets. Error message: %1$s."
+msgid "Failed trying to receive the order from Nets. Error message: %s."
 msgstr ""
 
 #: classes/class-dibs-api-callbacks.php:176
@@ -144,7 +144,7 @@ msgstr ""
 #: includes/dibs-checkout-functions.php:225
 #, php-format
 msgid ""
-"New payment created in Nets Easy with Payment ID %1$s. Payment type - %2$s. "
+"New payment created in Nets Easy with Payment ID %s. Payment type - %s. "
 "Awaiting charge."
 msgstr ""
 
@@ -213,9 +213,9 @@ msgstr ""
 #. Nets refund ID.
 #: classes/class-dibs-easy-gateway.php:169
 #, php-format
-msgid "Refund made in Nets Easy with refund ID %1$s. Reason: %2$s"
+msgid "Refund made in Nets Easy with refund ID %s. Reason: %s"
 msgstr ""
-"Återbetalnings genomförd i Nets Easy med återbetalnings ID %1$s. Orsak: %2$s"
+"Återbetalnings genomförd i Nets Easy med återbetalnings ID %s. Orsak: %s"
 
 #: classes/class-dibs-easy-gateway.php:197
 msgid "Order finalized in thankyou page."
@@ -224,9 +224,9 @@ msgstr ""
 #: classes/class-dibs-order-submission-failure.php:51
 #, php-format
 msgid ""
-"New payment created in Nets Easy with Payment ID %1$s. Payment type - %2$s."
+"New payment created in Nets Easy with Payment ID %s. Payment type - %s."
 msgstr ""
-"Ny betalning skapad i Nets Easy med betalnings ID %1$s. Betalsätt - %2$s."
+"Ny betalning skapad i Nets Easy med betalnings ID %s. Betalsätt - %s."
 
 #: classes/class-dibs-order-submission-failure.php:56
 msgid ""

--- a/languages/dibs-easy-for-woocommerce.pot
+++ b/languages/dibs-easy-for-woocommerce.pot
@@ -90,12 +90,12 @@ msgstr ""
 
 #: classes/class-dibs-subscriptions.php:235
 #, php-format
-msgid "Subscription payment made with Nets. Payment ID: %1$s. Charge ID %2$s."
+msgid "Subscription payment made with Nets. Payment ID: %s. Charge ID %s."
 msgstr ""
 
 #: classes/class-dibs-subscriptions.php:241
 #, php-format
-msgid "Subscription payment failed with Nets. Error message: %1$s."
+msgid "Subscription payment failed with Nets. Error message: %s."
 msgstr ""
 
 #: classes/class-dibs-subscriptions.php:276
@@ -106,7 +106,7 @@ msgstr ""
 #: classes/class-dibs-subscriptions.php:282
 #, php-format
 msgid ""
-"Payment status not correct for subscription. Status: %1$s. Message: %2$s"
+"Payment status not correct for subscription. Status: %s. Message: %s"
 msgstr ""
 
 #: classes/class-dibs-subscriptions.php:288
@@ -117,7 +117,7 @@ msgstr ""
 
 #: classes/class-dibs-api-callbacks.php:148
 #, php-format
-msgid "Failed trying to receive the order from Nets. Error message: %1$s."
+msgid "Failed trying to receive the order from Nets. Error message: %s."
 msgstr ""
 
 #: classes/class-dibs-api-callbacks.php:176
@@ -141,7 +141,7 @@ msgstr ""
 #: includes/dibs-checkout-functions.php:225
 #, php-format
 msgid ""
-"New payment created in Nets Easy with Payment ID %1$s. Payment type - %2$s. "
+"New payment created in Nets Easy with Payment ID %s. Payment type - %s. "
 "Awaiting charge."
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 #. Nets refund ID.
 #: classes/class-dibs-easy-gateway.php:169
 #, php-format
-msgid "Refund made in Nets Easy with refund ID %1$s. Reason: %2$s"
+msgid "Refund made in Nets Easy with refund ID %s. Reason: %s"
 msgstr ""
 
 #: classes/class-dibs-easy-gateway.php:197
@@ -220,7 +220,7 @@ msgstr ""
 #: classes/class-dibs-order-submission-failure.php:51
 #, php-format
 msgid ""
-"New payment created in Nets Easy with Payment ID %1$s. Payment type - %2$s."
+"New payment created in Nets Easy with Payment ID %s. Payment type - %s."
 msgstr ""
 
 #: classes/class-dibs-order-submission-failure.php:56


### PR DESCRIPTION
The `argnum` in the format specifier caused certain translation plugin to fail due to fatal error.

```
2022-02-02T07:16:36+00:00 CRITICAL Uncaught ValueError: Unknown format specifier " " in /var/www/vhosts/site/httpdocs/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php:262
Stack trace:
#0 /var/www/vhosts/site/httpdocs/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php(262): sprintf()
#1 /var/www/vhosts/site/httpdocs/wp-content/plugins/dibs-easy-for-woocommerce/classes/class-dibs-confirmation.php(64): wc_dibs_confirm_dibs_order()
#2 /var/www/vhosts/site/httpdocs/wp-includes/class-wp-hook.php(307): DIBS_Confirmation->confirm_order()
#3 /var/www/vhosts/site/httpdocs/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters()
#4 /var/www/vhosts/site/httpdocs/wp-includes/plugin.php(474): WP_Hook->do_action()
#5 /var/www/vhosts/site/httpdocs/wp-settings.php(587): do_action()
#6 /var/www/vhosts/site/httpdocs/wp-config.php(56): require_once('...')
#7 /var/www/vhosts/site/httpdocs/wp-load.php(50): require_once('...')
#8 /var/www/vhosts/site/httpdocs/wp-blog-header.php(13): require_once('...')
#9 /var/www/vhosts/site/httpdocs/index.php(17): require('...')
#10 {main}
thrown i /var/www/vhosts/site/httpdocs/wp-content/plugins/dibs-easy-for-woocommerce/includes/dibs-checkout-functions.php på linje 262
```

The most likely cause is that the third-party translation API that these plugins rely on is stripping part of the text that they consider to be malicious. Additionally, since the `argnum` is redundant (each format specifier already matches the order of the arguments), it is safe to remove them.