### PR TITLE
Fix plugin tries to create an empty nets order on order received page.

### DIFF
--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -67,7 +67,7 @@ class Nets_Easy_Assets {
 			return;
 		}
 		$test_mode = $settings['test_mode'];
-		if ( is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+		if ( is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) && ! is_order_received_page() ) {
 			$script_url = $this->get_script_url();
 
 			if ( WC()->session->get( 'dibs_payment_id' ) ) {


### PR DESCRIPTION
Not exactly sure what the root cause is but if you have both Nets and Klarna enabled and make an order through _order-pay_, with klarna, the plugin sends an empty order to Nets.

I don't think this should be called at all so I'm attempting to exit out the script early and only run it on the checkout page itself. Not on the _order received_ page.

The problem is that` dibs_easy_maybe_create_order()` runs when you have paid an order with Klarna through _order-pay_ and landing on _order-received_ page.

https://github.com/krokedil/dibs-easy-for-woocommerce/blob/12ead45b27cd08bbe326a91b15d5e2d36ddfa2e8/classes/class-nets-easy-assets.php#L70-L79

Because the cart is empty it triggers an error coming from the API that's shown on Klarna "thank you" page

> Items are required Amount must be greater than 0

https://github.com/krokedil/dibs-easy-for-woocommerce/blob/fb16fe4aa08fb762f40a18bb1ccd84682ab670e9/classes/class-nets-easy-api.php#L30-L38