### PR TITLE
Add support for unscheduled subscription

### DIFF
--- a/classes/class-nets-easy-api.php
+++ b/classes/class-nets-easy-api.php
@@ -143,15 +143,34 @@ class Nets_Easy_API {
 	}
 
 	/**
-	 * Charge subscription.
+	 * Charge scheduled subscription.
 	 *
 	 * @param int    $order_id The WooCommerce order id.
 	 * @param string $recurring_token Subscription token.
 	 *
 	 * @return array|mixed
 	 */
-	public function charge_nets_easy_subscription( $order_id, $recurring_token ) {
+	public function charge_nets_easy_scheduled_subscription( $order_id, $recurring_token ) {
 		$request  = new Nets_Easy_Request_Charge_Subscription(
+			array(
+				'order_id'        => $order_id,
+				'recurring_token' => $recurring_token,
+			)
+		);
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Charge unscheduled subscription.
+	 *
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $recurring_token Subscription token.
+	 *
+	 * @return array|mixed
+	 */
+	public function charge_nets_easy_unscheduled_subscription( $order_id, $recurring_token ) {
+		$request  = new Nets_Easy_Request_Charge_Unscheduled_Subscription(
 			array(
 				'order_id'        => $order_id,
 				'recurring_token' => $recurring_token,
@@ -207,6 +226,25 @@ class Nets_Easy_API {
 	 */
 	public function get_nets_easy_subscription_by_external_reference( $dibs_ticket, $order_id ) {
 		$request  = new Nets_Easy_Request_Get_Subscription_By_External_Reference(
+			array(
+				'external_reference' => $dibs_ticket,
+				'order_id'           => $order_id,
+			)
+		);
+		$response = $request->request();
+		return $this->check_for_api_error( $response );
+	}
+
+	/**
+	 * Retrieves a unscheduled subscription by external reference
+	 *
+	 * @param string $dibs_ticket The external reference to search for.
+	 * @param int    $order_id The WooCommerce order id.
+	 *
+	 * @return array|mixed
+	 */
+	public function get_nets_easy_unscheduled_subscription_by_external_reference( $dibs_ticket, $order_id ) {
+		$request  = new Nets_Easy_Request_Get_Unscheduled_Subscription_By_External_Reference(
 			array(
 				'external_reference' => $dibs_ticket,
 				'order_id'           => $order_id,

--- a/classes/class-nets-easy-subscriptions.php
+++ b/classes/class-nets-easy-subscriptions.php
@@ -398,7 +398,7 @@ class Nets_Easy_Subscriptions {
 	 */
 	public function save_dibs_recurring_token_update( $post_id, $post ) {
 		$order = wc_get_order( $post_id );
-		if ( class_exists( 'WC_Subscriptions' ) && wcs_order_contains_subscription( $order ) && get_post_meta( $post_id, '_dibs_recurring_token' ) ) {
+		if ( 'shop_subscription' === $order->get_type() && get_post_meta( $order->get_id(), '_dibs_recurring_token' ) ) {
 			$dibs_recurring_token = filter_input( INPUT_POST, '_dibs_recurring_token', FILTER_SANITIZE_STRING );
 			if ( ! empty( $dibs_recurring_token ) ) {
 				update_post_meta( $post_id, '_dibs_recurring_token', $dibs_recurring_token );

--- a/classes/requests/get/class-nets-easy-request-get-unscheduled-subscription-by-external-reference.php
+++ b/classes/requests/get/class-nets-easy-request-get-unscheduled-subscription-by-external-reference.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Get Subscription by External ID request class
+ *
+ * @package DIBS_Easy/Classes/Requests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Get Subscription by External ID request class
+ */
+class Nets_Easy_Request_Get_Unscheduled_Subscription_By_External_Reference extends Nets_Easy_Request_Get {
+
+	/**
+	 * $external_reference.
+	 *
+	 * @var string
+	 */
+	public $external_reference;
+
+
+	/**
+	 * Class Constructor.
+	 *
+	 * @param array $arguments The request args.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->external_reference = $arguments['external_reference'];
+
+	}
+
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->endpoint . 'unscheduledsubscriptions?externalreference=' . $this->external_reference;
+	}
+}

--- a/classes/requests/post/class-nets-easy-request-charge-unscheduled-subscription.php
+++ b/classes/requests/post/class-nets-easy-request-charge-unscheduled-subscription.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Charge unscheduled subscription renewal order request class
+ *
+ * @package DIBS_Easy/Classes/Requests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Charge unscheduled subscription renewal order request class
+ */
+class Nets_Easy_Request_Charge_Unscheduled_Subscription extends Nets_Easy_Request_Post {
+
+	/**
+	 * The WooCommerce order id.
+	 *
+	 * @var int $order_id
+	 */
+	public $order_id;
+
+	/**
+	 * @var mixed
+	 */
+	public $recurring_token;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $arguments The request args.
+	 */
+	public function __construct( $arguments ) {
+		parent::__construct( $arguments );
+		$this->log_title       = 'Charge unscheduled subscription';
+		$this->order_id        = $arguments['order_id'];
+		$this->recurring_token = $arguments['recurring_token'];
+	}
+
+
+	/**
+	 * Get the body for the request.
+	 *
+	 * @return array
+	 */
+	protected function get_body() {
+		$order                      = wc_get_order( $this->order_id );
+		$body                       = array();
+		$body['order']['items']     = Nets_Easy_Order_Items_Helper::get_items( $this->order_id );
+		$body['order']['amount']    = intval( round( $order->get_total() * 100 ) );
+		$body['order']['currency']  = $order->get_currency();
+		$body['order']['reference'] = $order->get_order_number();
+		return $body;
+	}
+
+	/**
+	 * Get the request url.
+	 *
+	 * @return string
+	 */
+	protected function get_request_url() {
+		return $this->endpoint . 'unscheduledsubscriptions/' . $this->recurring_token . '/charges';
+	}
+}

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.0.3
+ * Version:                 2.0.4
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.0.3' );
+define( 'WC_DIBS_EASY_VERSION', '2.0.4' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -153,9 +153,11 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 			include_once plugin_basename( 'classes/requests/post/class-nets-easy-request-refund-order.php' );
 			include_once plugin_basename( 'classes/requests/get/class-nets-easy-request-get-order.php' );
 			include_once plugin_basename( 'classes/requests/post/class-nets-easy-request-charge-subscription.php' );
+			include_once plugin_basename( 'classes/requests/post/class-nets-easy-request-charge-unscheduled-subscription.php' );
 			include_once plugin_basename( 'classes/requests/get/class-nets-easy-request-get-subscription-bulk-charge-id.php' );
 			include_once plugin_basename( 'classes/requests/get/class-nets-easy-request-get-subscription.php' );
 			include_once plugin_basename( 'classes/requests/get/class-nets-easy-request-get-subscription-by-external-reference.php' );
+			include_once plugin_basename( 'classes/requests/get/class-nets-easy-request-get-unscheduled-subscription-by-external-reference.php' );
 
 			include_once plugin_basename( 'classes/requests/helpers/class-nets-easy-checkout-helper.php' );
 			include_once plugin_basename( 'classes/requests/helpers/class-nets-easy-cart-helper.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.0
+Tested up to: 6.0.1
 Requires PHP: 7.0
 WC requires at least: 5.0.0
 WC tested up to: 6.7.0
@@ -56,6 +56,12 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2022.07.14    - version 2.0.4 =
+* Fix           - Fixed a critical error happening when attempting to process and print an error message.
+* Fix           - Fixed checkout template filter not working with Redis Cache (thanks @oxyc!)
+* Tweak         - Plugin assets won't be loaded on the thank-you page anymore.
+* Tweak         - We no longer create a new session unless the selected payment method is Nets Easy.
+
 = 2022.06.30    - version 2.0.3 =
 * Fix           - Fix issues with error handling from the Nets API with order management. Solves the errors that would show as "Uncaught Error" in the WooCommerce logs.
 


### PR DESCRIPTION
Nets Easy now offer two different ways of handling subscriptions. `Scheduled subscriptions` and `Unscheduled subscriptions`. Both of these works in the same way:
1. The customer add a subscription product to cart.
2. In the data sent to Nets we specify that the cart contain a recurring item.
3. When payment is done we receive a recurring token that can be used for future renewal purchases.

**The difference between unscheduled and scheduled subscriptions is**:
1. Scheduled subscriptions should be used when the recurring interval and the recurring amount always is the same.
2. Unscheduled subscriptions should be used when the recurring interval and recurring amount might differ between renewals. 

According to Nets there is no difference in pricing between the two types of charges. Both me (Niklas) and Giv at Nets suggest that we over time move over to unscheduled subscriptions as the default logic, since we do not know how merchants will use WooCommerce Subscriptions together with Nets Easy.

Also worth mentioning is that the only difference between the two subscription types is how Nets make their charges/calls against Visa and Mastercard. If using scheduled subscriptions and changing interval and amount on a regular basis _might_ increase the risk of getting renewal payments denied by the bank.

### Solution in this PR - step 1 of 2
This PR introduces support for unscheduled subscriptions via a filter. There is currently no setting for this. Before we can do that we need to discuss it closer with Nets.

To enable support fo unscheduled subscriptions you add the following snippet to your project:
```
add_filter('nets_easy_subscription_type', 'krokedil_nets_easy_subscription_type');

function krokedil_nets_easy_subscription_type() {
  return 'unscheduled_subscription';
}
```