### PR TITLE
develop-Issue-150-iPhone--Safari---sessionStoragegetItem-DIBSRedirectUrl--empty-when-returning-from-payment-gateway

### DIFF
--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -41,7 +41,7 @@ class Nets_Easy_Confirmation {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'confirm_order' ), 10, 2 );
-
+		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
 	}
 
 
@@ -68,6 +68,63 @@ class Nets_Easy_Confirmation {
 			wc_dibs_confirm_dibs_order( $order_id );
 			wc_dibs_unset_sessions();
 		}
+	}
+
+	/**
+	 * This function is used when customer is redirected from a payment page.
+	 * The main reason for this is when a purchase is done on mobile phone with a non default browser.
+	 * Bank ID/Vipps/Swish might then redirect the customer back to the stores checkout page,
+	 * but in the default browser. In this scenario it dosesnt exist a cart session in WooCommerce.
+	 * Instead of trying to display the embedded checkout we grab the payment_id and check the status.
+	 * If payment is created, we redirect the customer to the order thankyou page.
+	 *
+	 * This function is trigggered on init - on priority 20.
+	 * It needs to be triggered after similar logic in the subscription class (dibs_payment_method_changed).
+	 */
+	public function maybe_confirm_customer_redirected_from_payment_page_order() {
+
+		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_STRING );
+
+		if ( empty( $payment_id ) ) {
+			return;
+		}
+
+		Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Checking payment status.' );
+
+		$request = Nets_Easy()->api->get_nets_easy_order( $payment_id );
+
+		if ( is_wp_error( $request ) ) {
+			return;
+		}
+
+		if ( isset( $request['payment']['summary']['reservedAmount'] ) || isset( $request['payment']['summary']['chargedAmount'] ) || isset( $request['payment']['subscription']['id'] ) ) {
+
+			$order_id = nets_easy_get_order_id_by_purchase_id( $payment_id );
+			$order    = wc_get_order( $order_id );
+
+			if ( ! is_object( $order ) ) {
+				return;
+			}
+
+			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment created. Order ID ' . $order_id );
+
+			if ( empty( $order->get_date_paid() ) ) {
+
+				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order_id . '. Confirming the order.' );
+				// Confirm the order.
+				wc_dibs_confirm_dibs_order( $order_id );
+				wc_dibs_unset_sessions();
+				wp_safe_redirect( html_entity_decode( $order->get_checkout_order_received_url() ) );
+				exit;
+
+			} else {
+				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order_id . '. Order already confirmed.' );
+				return;
+			}
+		} else {
+			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment status is NOT paid.' );
+		}
+
 	}
 }
 Nets_Easy_Confirmation::get_instance();

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -329,3 +329,35 @@ function dibs_easy_print_error_message( $wp_error ) {
 	}
 }
 
+/**
+ * Finds an Order ID based on a payment ID (the Nets order number).
+ *
+ * @param string $payment_id Nets order number saved as Payment ID in WC order.
+ * @return int The ID of an order, or 0 if the order could not be found.
+ */
+function nets_easy_get_order_id_by_purchase_id( $payment_id ) {
+	$query_args = array(
+		'fields'      => 'ids',
+		'post_type'   => wc_get_order_types(),
+		'post_status' => array_keys( wc_get_order_statuses() ),
+		'meta_key'    => '_dibs_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'meta_value'  => sanitize_text_field( wp_unslash( $payment_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'date_query'  => array(
+			array(
+				'after' => '30 day ago',
+			),
+		),
+	);
+
+	$orders = get_posts( $query_args );
+
+	if ( $orders ) {
+		$order_id = $orders[0];
+	} else {
+		$order_id = 0;
+	}
+
+	return $order_id;
+}
+
+


### PR DESCRIPTION
Add support for checking payment status if paymentId is added as a query param.

This function is used when customer is redirected from a payment page back to checkout page.

The main reason for this is when a purchase is done on mobile phone with a non default browser. Bank ID/Vipps/Swish might then redirect the customer back to the stores checkout page, but in the default browser. In this scenario it doesn't exist a cart session in WooCommerce. Instead of trying to display the embedded checkout we grab the payment_id and check the status. If payment is created, we redirect the customer to the order thankyou page.

This function is triggered on init - on priority 20. It needs to be triggered after similar logic in the subscription class (dibs_payment_method_changed).