### PR TITLE
Change logic in wc_dibs_clean_name so we now exclude certain characters

### DIFF
--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -174,8 +174,9 @@ function wc_dibs_get_locale() {
  * @param string $name Name to be cleaned.
  */
 function wc_dibs_clean_name( $name ) {
-	$regex = '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9\x{00A1}-\x{00AC}\x{00AE}-\x{00FF}\x{0100}-\x{017F}\x{0180}-\x{024F}\x{0250}-\x{02AF}\x{02B0}-\x{02FF}\x{0300}-\x{036F}\s]+/u';
-	$name  = mb_ereg_replace( $regex, '', $name );
+	$not_allowed_characters = array( '<', '>', '\\', '"', '&' );
+	$name                   = wp_strip_all_tags( $name );
+	$name                   = str_replace( $not_allowed_characters, '', $name );
 
 	return substr( $name, 0, 128 );
 }


### PR DESCRIPTION
Previously we allowed certain characters. Now instead we exclude specific characters + use `wp_strip_all_tags()` to remove html tags. 

According to Nets only the following characters are not accepted by their system:
`<, >, \, ", &`