### PR TITLE
Version 2.2.2

### DIFF
--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -45,6 +45,14 @@ class Nets_Easy_Checkout {
 			return;
 		}
 
+		// Check that the currency is the same as earlier, otherwise create a new session.
+		if ( get_woocommerce_currency() !== WC()->session->get( 'nets_easy_currency' ) ) {
+			wc_dibs_unset_sessions();
+			Nets_Easy_Logger::log( 'Currency changed in update Nets function. Clearing Nets session and reloading the checkout page.' );
+			WC()->session->reload_checkout = true;
+			return;
+		}
+
 		// Check if the cart hash has been changed since last update.
 		$cart_hash  = $cart->get_cart_hash();
 		$saved_hash = WC()->session->get( 'nets_easy_last_update_hash' );

--- a/classes/requests/helpers/class-nets-easy-notification-helper.php
+++ b/classes/requests/helpers/class-nets-easy-notification-helper.php
@@ -35,8 +35,9 @@ class Nets_Easy_Notification_Helper {
 	public static function get_web_hooks() {
 		$web_hooks = array();
 
-		// Only set web hooks if host is not local (127.0.0.1 or ::1).
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) || isset( $_SERVER['HTTP_HOST'] ) && 'localhost' === substr( $_SERVER['HTTP_HOST'], 0, 9 ) ) {
+		// Do not send webhook url if this site is declared as a local environment via wp_get_environment_type().
+		// Read more about wp_get_environment_type https://developer.wordpress.org/reference/functions/wp_get_environment_type/.
+		if ( function_exists( 'wp_get_environment_type' ) && apply_filters( 'nets_easy_environment_without_public_url', 'local' ) === wp_get_environment_type() ) {
 			return $web_hooks;
 		} else {
 			$web_hooks[] = array(

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.2.0
+ * Version:                 2.2.1
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.1.0
+ * WC tested up to:         7.2.0
  * Copyright:               © 2017-2022 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.2.0' );
+define( 'WC_DIBS_EASY_VERSION', '2.2.1' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.2.0
+ * WC tested up to:         7.2.2
  * Copyright:               © 2017-2022 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.2.1
+ * Version:                 2.2.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,8 +16,8 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.2.2
- * Copyright:               © 2017-2022 Krokedil AB.
+ * WC tested up to:         7.4.0
+ * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.2.1' );
+define( 'WC_DIBS_EASY_VERSION', '2.2.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -174,8 +174,9 @@ function wc_dibs_get_locale() {
  * @param string $name Name to be cleaned.
  */
 function wc_dibs_clean_name( $name ) {
-	$regex = '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9\x{00A1}-\x{00AC}\x{00AE}-\x{00FF}\x{0100}-\x{017F}\x{0180}-\x{024F}\x{0250}-\x{02AF}\x{02B0}-\x{02FF}\x{0300}-\x{036F}\s]+/u';
-	$name  = mb_ereg_replace( $regex, '', $name );
+	$not_allowed_characters = array( '<', '>', '\\', '"', '&' );
+	$name                   = wp_strip_all_tags( $name );
+	$name                   = str_replace( $not_allowed_characters, '', $name );
 
 	return substr( $name, 0, 128 );
 }

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -39,7 +39,7 @@ function dibs_easy_maybe_create_order() {
 	}
 	// store payment id.
 	$session->set( 'dibs_payment_id', $dibs_easy_order['paymentId'] );
-	$session->set( 'dibs_currency', get_woocommerce_currency() );
+	$session->set( 'nets_easy_currency', get_woocommerce_currency() );
 	$session->set( 'nets_easy_last_update_hash', $cart->get_cart_hash() );
 	$session->set( 'dibs_cart_contains_subscription', get_dibs_cart_contains_subscription() );
 	// Set a transient for this paymentId. It's valid in DIBS system for 20 minutes.
@@ -109,8 +109,8 @@ function wc_dibs_unset_sessions() {
 		if ( WC()->session->get( 'dibs_customer_order_note' ) ) {
 			WC()->session->__unset( 'dibs_customer_order_note' );
 		}
-		if ( WC()->session->get( 'dibs_currency' ) ) {
-			WC()->session->__unset( 'dibs_currency' );
+		if ( WC()->session->get( 'nets_easy_currency' ) ) {
+			WC()->session->__unset( 'nets_easy_currency' );
 		}
 
 		if ( WC()->session->get( 'dibs_cart_contains_subscription' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.0
 Tested up to: 6.1.1
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.2.2
-Stable tag: 2.2.1
+WC tested up to: 7.4.0
+Stable tag: 2.2.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,12 +50,16 @@ Available for merchants in Denmark, Sweden and Norway.
 For help setting up and configuring Nets Easy for WooCommerce please refer to our [documentation](http://docs.krokedil.com/documentation/nets-easy-for-woocommerce/).
 
 = Are there any specific requirements? =
-* WooCommerce 3.5 or newer is required.
-* PHP 5.6 or higher is required.
+* WooCommerce 5.0 or newer is required.
+* PHP 7.2 or higher is required.
 * A SSL Certificate is required.
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.02.28    - version 2.2.2 =
+* Tweak         - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
+* fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
+
 = 2022.12.14    - version 2.2.1 =
 * Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.
 * Fix           - Avoid fatal error in confirmation sequence if request to Nets fails. 

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
 Tested up to: 6.1
-Requires PHP: 7.0
+Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.1.0
-Stable tag: 2.2.0
+WC tested up to: 7.2.0
+Stable tag: 2.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,11 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2022.12.14    - version 2.2.1 =
+* Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.
+* Fix           - Avoid fatal error in confirmation sequence if request to Nets fails. 
+* Fix           - Avoid fatal error in process payment sequence (redirect checkout flow) if request to Nets fails.
+
 = 2022.11.09    - version 2.2.0 =
 * Feature       - Adds customer name and address in create session request to Nets (if they exist in Woo) for embedded checkout.
 * Tweak         - Sends cancel url in payment requests to Nets.

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 == CHANGELOG ==
 = 2023.02.28    - version 2.2.2 =
 * Tweak         - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
-* fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
+* Fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
 
 = 2022.12.14    - version 2.2.1 =
 * Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.1
+Tested up to: 6.1.1
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.2.0
+WC tested up to: 7.2.2
 Stable tag: 2.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
* Tweak - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
* Fix - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.