### PR TITLE
Change logic for auto capture

### DIFF
--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -26,6 +26,7 @@ class Nets_Easy_Checkout_Helper {
 	 */
 	public static function get_checkout( $checkout_flow = 'embedded', $order_id = null ) {
 		$dibs_settings = get_option( 'woocommerce_dibs_easy_settings' );
+		$auto_capture  = $dibs_settings['auto_capture'] ?? 'no';
 
 		$checkout = array(
 			'termsUrl' => wc_get_page_permalink( 'terms' ),
@@ -76,6 +77,12 @@ class Nets_Easy_Checkout_Helper {
 				break;
 			default:
 				$checkout['consumerType']['supportedTypes'] = array( 'B2B' );
+		}
+
+		// Capture transaction directly when reservation has been accepted?
+		// https://developers.nets.eu/nets-easy/en-EU/api/payment-v1/#v1-payments-post-body-checkout-charge.
+		if ( 'yes' === $auto_capture ) {
+			$checkout['charge'] = true;
 		}
 
 		return $checkout;

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -193,7 +193,6 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 	$payment_id    = get_post_meta( $order_id, '_dibs_payment_id', true );
 	$settings      = get_option( 'woocommerce_dibs_easy_settings' );
 	$checkout_flow = $settings['checkout_flow'] ?? 'embedded';
-	$auto_capture  = $settings['auto_capture'] ?? 'no';
 
 	if ( null === $payment_id ) {
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
@@ -229,7 +228,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 			update_post_meta( $order_id, 'dibs_customer_card', $request['payment']['paymentDetails']['cardDetails']['maskedPan'] );
 		}
 
-		if ( 'A2A' === $request['payment']['paymentDetails']['paymentType'] ) {
+		if ( isset( $request['payment']['charges'][0]['chargeId'] ) && ! empty( $request['payment']['charges'][0]['chargeId'] ) ) {
 			// Get the DIBS order charge ID.
 			$dibs_charge_id = $request['payment']['charges'][0]['chargeId'];
 			update_post_meta( $order_id, '_dibs_charge_id', $dibs_charge_id );
@@ -242,9 +241,6 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 		}
 		$order->payment_complete( $payment_id );
 
-		if ( 'yes' === $auto_capture ) {
-			Nets_Easy()->order_management->dibs_order_completed( $order_id );
-		}
 	} else {
 		// Purchase not finalized in DIBS.
 		// If this is a redirect checkout flow let's redirect the customer to cart page.


### PR DESCRIPTION
We now send charge = true in the create request and look for a charge id in payment confirmation, instead of making an activation request in payment confirmation sequenze.