### PR TITLE
Change sku sent for YITH giftcard plugin

### DIFF
--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -49,7 +49,7 @@ class Nets_Easy_Cart_Helper {
 			foreach ( WC()->cart->applied_gift_cards as $coupon_key => $code ) {
 				$coupon_amount = isset( WC()->cart->applied_gift_cards_amounts[ $code ] ) ? - WC()->cart->applied_gift_cards_amounts[ $code ] * 100 : 0;
 				$label         = apply_filters( 'yith_ywgc_cart_totals_gift_card_label', esc_html( __( 'Gift card:', 'yith-woocommerce-gift-cards' ) . ' ' . $code ), $code );
-				$giftcard_sku  = apply_filters( 'nets_yith_gift_card_sku', esc_html( __( 'giftcard', 'dibs-easy-for-woocommerce' ) ), $code );
+				$giftcard_sku  = apply_filters( 'nets_yith_gift_card_sku', esc_html( $code ), $code );
 
 				$gift_card = array(
 					'reference'        => $giftcard_sku,

--- a/classes/requests/helpers/class-nets-easy-order-items-helper.php
+++ b/classes/requests/helpers/class-nets-easy-order-items-helper.php
@@ -186,10 +186,14 @@ class Nets_Easy_Order_Items_Helper {
 
 		if ( ! empty( $yith_giftcards ) ) {
 			foreach ( $yith_giftcards as $yith_giftcard_code => $yith_giftcard_value ) {
+
+				$label        = apply_filters( 'yith_ywgc_cart_totals_gift_card_label', esc_html( __( 'Gift card:', 'yith-woocommerce-gift-cards' ) . ' ' . $yith_giftcard_code ), $yith_giftcard_code );
+				$giftcard_sku = apply_filters( 'nets_yith_gift_card_sku', esc_html( $yith_giftcard_code ), $code );
+
 				$yith_giftcard_value = $yith_giftcard_value * 100 * -1;
 				$items[]             = array(
-					'reference'        => 'gift_card',
-					'name'             => 'Gift card',
+					'reference'        => $giftcard_sku,
+					'name'             => $label,
 					'quantity'         => '1',
 					'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
 					'unitPrice'        => $yith_giftcard_value,


### PR DESCRIPTION
* With this PR we now use `giftcard code` (giftcard name modified via `strtoupper`). 
* The gift card _code_ and _amount_ can also be fetched via WooCommerce API (via the meta_data field `_ywgc_applied_gift_cards`). Useful for Kroconnect and other external systems to get the ciftcard code and amount.
* Also tweak to giftcard _name_ sent to Nets, use the format `Gift card: {gifdcard_code}`.