### PR TITLE
Tweak: Create session later to avoid unnecessary creation of payment id

### DIFF
--- a/assets/js/nets-easy-utility.js
+++ b/assets/js/nets-easy-utility.js
@@ -1,0 +1,61 @@
+/**
+ * @member nets_easy_utility_params
+ *
+ */
+jQuery( function( $ ) {
+	if ( typeof nets_easy_utility_params === 'undefined' ) {
+		return false;
+	}
+	/**
+	 * The main object.
+	 *
+	 * @type {Object} netsEasyUtility
+	 */
+	const netsEasyUtility = {
+		bodyEl: $( 'body' ),
+        checkoutFormSelector: 'form.checkout',
+
+		/**
+		 * Initialize the gateway
+		 */
+		init() {
+			netsEasyUtility.bodyEl.on(
+				'change',
+				'input[name="payment_method"]',
+				netsEasyUtility.maybeChangeToDibsEasy
+			);
+		},
+		
+		/**
+		 * When the customer changes to Dibs Easy from other payment methods.
+		 */
+		maybeChangeToDibsEasy() {
+			if ( 'dibs_easy' === $( this ).val() ) {
+				$( '.woocommerce-info' ).remove();
+				$( netsEasyUtility.checkoutFormSelector ).block( {
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6,
+					},
+				} );
+				$.ajax( {
+					type: 'POST',
+					data: {
+						nonce: nets_easy_utility_params.nets_checkout_nonce,
+					},
+					dataType: 'json',
+					url: nets_easy_utility_params.change_payment_method_url,
+					success( data ) {},
+					error( data ) {},
+					complete( data ) {
+						window.location.href = data.responseJSON.data.redirect;
+					},
+				} );
+			}
+		},
+		
+	};
+
+	netsEasyUtility.init();
+} );

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -25,11 +25,14 @@ class Nets_Easy_Assets {
 	 * Dibs_Easy_Assets constructor.
 	 */
 	public function __construct() {
-		$this->settings = get_option( 'woocommerce_dibs_easy_settings', array() );
+		$this->settings  = get_option( 'woocommerce_dibs_easy_settings', array() );
+		$this->enabled   = $this->settings['enabled'] ?? 'no';
+		$this->test_mode = $this->settings['test_mode'] ?? 'no';
+
 		if ( ! ( empty( $this->settings ) ) && 'embedded' === $this->settings['checkout_flow'] ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_js' ), 10 );
+			add_action( 'wc_dibs_before_checkout_form', array( $this, 'localize_and_enqueue_checkout_script' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_css' ), 10 );
-
 		}
 
 	}
@@ -51,7 +54,7 @@ class Nets_Easy_Assets {
 	 * @return string
 	 */
 	protected function get_script_url() {
-		if ( 'yes' === $this->settings['test_mode'] ) {
+		if ( 'yes' === $this->test_mode ) {
 			return 'https://test.checkout.dibspayment.eu/v1/checkout.js?v=1';
 		}
 		return 'https://checkout.dibspayment.eu/v1/checkout.js?v=1';
@@ -61,9 +64,8 @@ class Nets_Easy_Assets {
 	 * Loads scripts for the plugin.
 	 */
 	public function dibs_load_js() {
-		$settings = get_option( 'woocommerce_dibs_easy_settings', array() );
 
-		if ( 'yes' !== $settings['enabled'] ) {
+		if ( 'yes' !== $this->enabled ) {
 			return;
 		}
 
@@ -77,8 +79,50 @@ class Nets_Easy_Assets {
 			return;
 		}
 
-		$test_mode  = $settings['test_mode'];
+		// Nets regular checkout script.
 		$script_url = $this->get_script_url();
+		wp_enqueue_script( 'dibs-script', $script_url, array( 'jquery' ), WC_DIBS_EASY_VERSION, false );
+
+		// Plugin checkout script. Registered here, but localized and enqueued on the wc_dibs_before_checkout_form hook.
+		$script_version = $this->nets_easy_is_script_debug_enabled();
+		$src            = WC_DIBS__URL . '/assets/js/nets-easy-for-woocommerce' . $script_version . '.js';
+		wp_register_script(
+			'nets-easy-checkout',
+			$src,
+			array(
+				'jquery',
+				'dibs-script',
+			),
+			WC_DIBS_EASY_VERSION,
+			false
+		);
+
+		// Checkout utility (change to Nets Easy payment method in checkout).
+		wp_register_script(
+			'nets_easy_utility',
+			WC_DIBS__URL . '/assets/js/nets-easy-utility.js',
+			array( 'jquery' ),
+			WC_DIBS_EASY_VERSION,
+			true
+		);
+
+		$params = array(
+			'change_payment_method_url' => WC_AJAX::get_endpoint( 'change_payment_method' ),
+			'nets_checkout_nonce'       => wp_create_nonce( 'nets_checkout' ),
+		);
+
+		wp_localize_script(
+			'nets_easy_utility',
+			'nets_easy_utility_params',
+			$params
+		);
+		wp_enqueue_script( 'nets_easy_utility' );
+	}
+
+	/**
+	 * Loads the needed scripts for Nets Easy.
+	 */
+	public function localize_and_enqueue_checkout_script() {
 
 		if ( WC()->session->get( 'dibs_payment_id' ) ) {
 			$checkout_initiated = 'yes';
@@ -116,22 +160,11 @@ class Nets_Easy_Assets {
 			'account_username',
 			'account_password',
 		);
-		$script_version               = $this->nets_easy_is_script_debug_enabled();
+
 		// todo enable min version.
 		// phpcs:ignore $src                          = WC_DIBS__URL . '/assets/js/checkout' . $script_version . '.js';
-		wp_enqueue_script( 'dibs-script', $script_url, array( 'jquery' ), WC_DIBS_EASY_VERSION, false );
-		$src = WC_DIBS__URL . '/assets/js/nets-easy-for-woocommerce' . $script_version . '.js';
-		wp_register_script(
-			'nets-easy-checkout',
-			$src,
-			array(
-				'jquery',
-				'dibs-script',
-			),
-			WC_DIBS_EASY_VERSION,
-			false
-		);
-		$private_key = 'yes' === $test_mode ? $settings['dibs_test_checkout_key'] : $settings['dibs_checkout_key'];
+
+		$private_key = 'yes' === $this->test_mode ? $this->settings['dibs_test_checkout_key'] : $this->settings['dibs_checkout_key'];
 		wp_localize_script(
 			'nets-easy-checkout',
 			'wcDibsEasy',


### PR DESCRIPTION
The initial idea was to be able to send and then display the address (entered by the customer in Woo checkout form) in Nets Easy embedded checkout. After closer discussion with Nets, this is not possible in their system.

However, instead we now improve the logic for embedded checkout flow so we don't need to create a Nets payment ID when the checkout page is rendered and Nets Easy isn't the first or selected payment gateway.