### PR TITLE
Version 2.3.0

### DIFF
--- a/assets/js/nets-easy-utility.js
+++ b/assets/js/nets-easy-utility.js
@@ -1,0 +1,61 @@
+/**
+ * @member nets_easy_utility_params
+ *
+ */
+jQuery( function( $ ) {
+	if ( typeof nets_easy_utility_params === 'undefined' ) {
+		return false;
+	}
+	/**
+	 * The main object.
+	 *
+	 * @type {Object} netsEasyUtility
+	 */
+	const netsEasyUtility = {
+		bodyEl: $( 'body' ),
+        checkoutFormSelector: 'form.checkout',
+
+		/**
+		 * Initialize the gateway
+		 */
+		init() {
+			netsEasyUtility.bodyEl.on(
+				'change',
+				'input[name="payment_method"]',
+				netsEasyUtility.maybeChangeToDibsEasy
+			);
+		},
+		
+		/**
+		 * When the customer changes to Dibs Easy from other payment methods.
+		 */
+		maybeChangeToDibsEasy() {
+			if ( 'dibs_easy' === $( this ).val() ) {
+				$( '.woocommerce-info' ).remove();
+				$( netsEasyUtility.checkoutFormSelector ).block( {
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6,
+					},
+				} );
+				$.ajax( {
+					type: 'POST',
+					data: {
+						nonce: nets_easy_utility_params.nets_checkout_nonce,
+					},
+					dataType: 'json',
+					url: nets_easy_utility_params.change_payment_method_url,
+					success( data ) {},
+					error( data ) {},
+					complete( data ) {
+						window.location.href = data.responseJSON.data.redirect;
+					},
+				} );
+			}
+		},
+		
+	};
+
+	netsEasyUtility.init();
+} );

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -25,11 +25,14 @@ class Nets_Easy_Assets {
 	 * Dibs_Easy_Assets constructor.
 	 */
 	public function __construct() {
-		$this->settings = get_option( 'woocommerce_dibs_easy_settings', array() );
+		$this->settings  = get_option( 'woocommerce_dibs_easy_settings', array() );
+		$this->enabled   = $this->settings['enabled'] ?? 'no';
+		$this->test_mode = $this->settings['test_mode'] ?? 'no';
+
 		if ( ! ( empty( $this->settings ) ) && 'embedded' === $this->settings['checkout_flow'] ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_js' ), 10 );
+			add_action( 'wc_dibs_before_checkout_form', array( $this, 'localize_and_enqueue_checkout_script' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_css' ), 10 );
-
 		}
 
 	}
@@ -51,7 +54,7 @@ class Nets_Easy_Assets {
 	 * @return string
 	 */
 	protected function get_script_url() {
-		if ( 'yes' === $this->settings['test_mode'] ) {
+		if ( 'yes' === $this->test_mode ) {
 			return 'https://test.checkout.dibspayment.eu/v1/checkout.js?v=1';
 		}
 		return 'https://checkout.dibspayment.eu/v1/checkout.js?v=1';
@@ -61,9 +64,8 @@ class Nets_Easy_Assets {
 	 * Loads scripts for the plugin.
 	 */
 	public function dibs_load_js() {
-		$settings = get_option( 'woocommerce_dibs_easy_settings', array() );
 
-		if ( 'yes' !== $settings['enabled'] ) {
+		if ( 'yes' !== $this->enabled ) {
 			return;
 		}
 
@@ -77,8 +79,50 @@ class Nets_Easy_Assets {
 			return;
 		}
 
-		$test_mode  = $settings['test_mode'];
+		// Nets regular checkout script.
 		$script_url = $this->get_script_url();
+		wp_enqueue_script( 'dibs-script', $script_url, array( 'jquery' ), WC_DIBS_EASY_VERSION, false );
+
+		// Plugin checkout script. Registered here, but localized and enqueued on the wc_dibs_before_checkout_form hook.
+		$script_version = $this->nets_easy_is_script_debug_enabled();
+		$src            = WC_DIBS__URL . '/assets/js/nets-easy-for-woocommerce' . $script_version . '.js';
+		wp_register_script(
+			'nets-easy-checkout',
+			$src,
+			array(
+				'jquery',
+				'dibs-script',
+			),
+			WC_DIBS_EASY_VERSION,
+			false
+		);
+
+		// Checkout utility (change to Nets Easy payment method in checkout).
+		wp_register_script(
+			'nets_easy_utility',
+			WC_DIBS__URL . '/assets/js/nets-easy-utility.js',
+			array( 'jquery' ),
+			WC_DIBS_EASY_VERSION,
+			true
+		);
+
+		$params = array(
+			'change_payment_method_url' => WC_AJAX::get_endpoint( 'change_payment_method' ),
+			'nets_checkout_nonce'       => wp_create_nonce( 'nets_checkout' ),
+		);
+
+		wp_localize_script(
+			'nets_easy_utility',
+			'nets_easy_utility_params',
+			$params
+		);
+		wp_enqueue_script( 'nets_easy_utility' );
+	}
+
+	/**
+	 * Loads the needed scripts for Nets Easy.
+	 */
+	public function localize_and_enqueue_checkout_script() {
 
 		if ( WC()->session->get( 'dibs_payment_id' ) ) {
 			$checkout_initiated = 'yes';
@@ -116,22 +160,11 @@ class Nets_Easy_Assets {
 			'account_username',
 			'account_password',
 		);
-		$script_version               = $this->nets_easy_is_script_debug_enabled();
+
 		// todo enable min version.
 		// phpcs:ignore $src                          = WC_DIBS__URL . '/assets/js/checkout' . $script_version . '.js';
-		wp_enqueue_script( 'dibs-script', $script_url, array( 'jquery' ), WC_DIBS_EASY_VERSION, false );
-		$src = WC_DIBS__URL . '/assets/js/nets-easy-for-woocommerce' . $script_version . '.js';
-		wp_register_script(
-			'nets-easy-checkout',
-			$src,
-			array(
-				'jquery',
-				'dibs-script',
-			),
-			WC_DIBS_EASY_VERSION,
-			false
-		);
-		$private_key = 'yes' === $test_mode ? $settings['dibs_test_checkout_key'] : $settings['dibs_checkout_key'];
+
+		$private_key = 'yes' === $this->test_mode ? $this->settings['dibs_test_checkout_key'] : $this->settings['dibs_checkout_key'];
 		wp_localize_script(
 			'nets-easy-checkout',
 			'wcDibsEasy',

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -135,7 +135,7 @@ class Nets_Easy_Assets {
 			}
 		}
 
-		$standard_woo_checkout_fields = array(
+		$standard_woo_checkout_fields = apply_filters( 'nets_easy_ignored_checkout_fields', array(
 			'billing_first_name',
 			'billing_last_name',
 			'billing_address_1',
@@ -159,7 +159,7 @@ class Nets_Easy_Assets {
 			'terms',
 			'account_username',
 			'account_password',
-		);
+		) );
 
 		// todo enable min version.
 		// phpcs:ignore $src                          = WC_DIBS__URL . '/assets/js/checkout' . $script_version . '.js';

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -15,7 +15,7 @@ class Nets_Easy_Checkout {
 	 * Class constructor
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_nets_easy_order' ), 9999 );
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_nets_easy_order' ), 999999 );
 	}
 
 	/**
@@ -56,6 +56,12 @@ class Nets_Easy_Checkout {
 		// Check if the cart hash has been changed since last update.
 		$cart_hash  = $cart->get_cart_hash();
 		$saved_hash = WC()->session->get( 'nets_easy_last_update_hash' );
+
+		// Gift cards may not change cart hash.
+		// Always trigger update if coupons exist to be compatible with Smart Coupons plugin.
+		if ( method_exists( $cart, 'get_coupons' ) && ! empty( WC()->cart->get_coupons() ) ) {
+			$saved_hash = '';
+		}
 
 		// If they are the same, return.
 		if ( $cart_hash === $saved_hash ) {

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -45,6 +45,12 @@ class Nets_Easy_Checkout {
 			return;
 		}
 
+		// Trigger get if the ajax event is among the approved ones.
+		$ajax = filter_input( INPUT_GET, 'wc-ajax', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		if ( ! in_array( $ajax, array( 'update_order_review' ), true ) ) {
+			return;
+		}
+
 		// Check that the currency is the same as earlier, otherwise create a new session.
 		if ( get_woocommerce_currency() !== WC()->session->get( 'nets_easy_currency' ) ) {
 			wc_dibs_unset_sessions();
@@ -78,6 +84,15 @@ class Nets_Easy_Checkout {
 				} else {
 					wp_safe_redirect( wc_get_checkout_url() );
 				}
+			}
+		}
+
+		// If cart doesn't need payment anymore - reload the checkout page.
+		if ( apply_filters( 'nets_easy_check_if_needs_payment', true ) && 'no' === get_dibs_cart_contains_subscription() ) {
+			if ( ! WC()->cart->needs_payment() ) {
+				Nets_Easy_Logger::log( 'Cart does not need payment. Reloading the checkout page.' );
+				WC()->session->reload_checkout = true;
+				return;
 			}
 		}
 

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -45,6 +45,14 @@ class Nets_Easy_Checkout {
 			return;
 		}
 
+		// Check that the currency is the same as earlier, otherwise create a new session.
+		if ( get_woocommerce_currency() !== WC()->session->get( 'nets_easy_currency' ) ) {
+			wc_dibs_unset_sessions();
+			Nets_Easy_Logger::log( 'Currency changed in update Nets function. Clearing Nets session and reloading the checkout page.' );
+			WC()->session->reload_checkout = true;
+			return;
+		}
+
 		// Check if the cart hash has been changed since last update.
 		$cart_hash  = $cart->get_cart_hash();
 		$saved_hash = WC()->session->get( 'nets_easy_last_update_hash' );

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -50,8 +50,8 @@ class Nets_Easy_Confirmation {
 	 */
 	public function confirm_order() {
 
-		$easy_confirm = filter_input( INPUT_GET, 'easy_confirm', FILTER_SANITIZE_STRING );
-		$order_key    = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+		$easy_confirm = filter_input( INPUT_GET, 'easy_confirm', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$order_key    = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( empty( $easy_confirm ) || empty( $order_key ) ) {
 			return;
 		}
@@ -83,7 +83,7 @@ class Nets_Easy_Confirmation {
 	 */
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
 
-		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_STRING );
+		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( empty( $payment_id ) ) {
 			return;

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -41,7 +41,7 @@ class Nets_Easy_Confirmation {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'confirm_order' ), 10, 2 );
-
+		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
 	}
 
 
@@ -68,6 +68,63 @@ class Nets_Easy_Confirmation {
 			wc_dibs_confirm_dibs_order( $order_id );
 			wc_dibs_unset_sessions();
 		}
+	}
+
+	/**
+	 * This function is used when customer is redirected from a payment page.
+	 * The main reason for this is when a purchase is done on mobile phone with a non default browser.
+	 * Bank ID/Vipps/Swish might then redirect the customer back to the stores checkout page,
+	 * but in the default browser. In this scenario it dosesnt exist a cart session in WooCommerce.
+	 * Instead of trying to display the embedded checkout we grab the payment_id and check the status.
+	 * If payment is created, we redirect the customer to the order thankyou page.
+	 *
+	 * This function is trigggered on init - on priority 20.
+	 * It needs to be triggered after similar logic in the subscription class (dibs_payment_method_changed).
+	 */
+	public function maybe_confirm_customer_redirected_from_payment_page_order() {
+
+		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_STRING );
+
+		if ( empty( $payment_id ) ) {
+			return;
+		}
+
+		Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Checking payment status.' );
+
+		$request = Nets_Easy()->api->get_nets_easy_order( $payment_id );
+
+		if ( is_wp_error( $request ) ) {
+			return;
+		}
+
+		if ( isset( $request['payment']['summary']['reservedAmount'] ) || isset( $request['payment']['summary']['chargedAmount'] ) || isset( $request['payment']['subscription']['id'] ) ) {
+
+			$order_id = nets_easy_get_order_id_by_purchase_id( $payment_id );
+			$order    = wc_get_order( $order_id );
+
+			if ( ! is_object( $order ) ) {
+				return;
+			}
+
+			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment created. Order ID ' . $order_id );
+
+			if ( empty( $order->get_date_paid() ) ) {
+
+				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order_id . '. Confirming the order.' );
+				// Confirm the order.
+				wc_dibs_confirm_dibs_order( $order_id );
+				wc_dibs_unset_sessions();
+				wp_safe_redirect( html_entity_decode( $order->get_checkout_order_received_url() ) );
+				exit;
+
+			} else {
+				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order_id . '. Order already confirmed.' );
+				return;
+			}
+		} else {
+			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment status is NOT paid.' );
+		}
+
 	}
 }
 Nets_Easy_Confirmation::get_instance();

--- a/classes/class-nets-easy-email.php
+++ b/classes/class-nets-easy-email.php
@@ -32,9 +32,10 @@ if ( ! class_exists( 'Nets_Easy_Email' ) ) :
 		 * @return void
 		 */
 		public function email_extra_information( $order, $sent_to_admin, $plain_text = false ) {
-			$settings     = get_option( 'woocommerce_dibs_easy_settings' );
-			$order_id     = $order->get_id();
-			$gateway_used = get_post_meta( $order_id, '_payment_method', true );
+			$settings                = get_option( 'woocommerce_dibs_easy_settings' );
+			$email_nets_payment_data = $settings['email_nets_payment_data'] ?? 'yes';
+			$order_id                = $order->get_id();
+			$gateway_used            = get_post_meta( $order_id, '_payment_method', true );
 			if ( 'dibs_easy' === $gateway_used ) {
 				$payment_id     = get_post_meta( $order_id, '_dibs_payment_id', true );
 				$customer_card  = get_post_meta( $order_id, 'dibs_customer_card', true );
@@ -44,17 +45,16 @@ if ( ! class_exists( 'Nets_Easy_Email' ) ) :
 				if ( $settings['email_text'] ) {
 					echo wp_kses_post( wpautop( wptexturize( $settings['email_text'] ) ) );
 				}
-				if ( $order_date ) {
-					echo wp_kses_post( wpautop( wptexturize( __( 'Order date: ', 'dibs-easy-for-woocommerce' ) . $order_date ) ) );
-				}
-				if ( $payment_id ) {
-					echo wp_kses_post( wpautop( wptexturize( __( 'Nets Payment ID: ', 'dibs-easy-for-woocommerce' ) . $payment_id ) ) );
-				}
-				if ( $payment_method ) {
-					echo wp_kses_post( wpautop( wptexturize( __( 'Payment method: ', 'dibs-easy-for-woocommerce' ) . $payment_method ) ) );
-				}
-				if ( $customer_card ) {
-					echo wp_kses_post( wpautop( wptexturize( __( 'Customer card: ', 'dibs-easy-for-woocommerce' ) . $customer_card ) ) );
+				if ( 'yes' === $email_nets_payment_data ) {
+					if ( $payment_id ) {
+						echo wp_kses_post( wpautop( wptexturize( __( 'Nets Payment ID: ', 'dibs-easy-for-woocommerce' ) . $payment_id ) ) );
+					}
+					if ( $payment_method ) {
+						echo wp_kses_post( wpautop( wptexturize( __( 'Payment method: ', 'dibs-easy-for-woocommerce' ) . $payment_method ) ) );
+					}
+					if ( $customer_card ) {
+						echo wp_kses_post( wpautop( wptexturize( __( 'Customer card: ', 'dibs-easy-for-woocommerce' ) . $customer_card ) ) );
+					}
 				}
 			}
 		}

--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -133,6 +133,12 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 		}
 		// Redirect flow.
 		$response = Nets_Easy()->api->create_nets_easy_order( 'redirect', $order_id );
+		if ( is_wp_error( $response ) ) {
+			wc_add_notice( $response->get_error_message(), 'error' );
+			return array(
+				'result' => 'error',
+			);
+		}
 		return $this->process_redirect_handler( $order_id, $response );
 	}
 

--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -39,9 +39,11 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 		// Load the settings.
 		$this->init_settings();
 		// Get the settings values.
-		$this->title         = $this->get_option( 'title' );
-		$this->enabled       = $this->get_option( 'enabled' );
-		$this->checkout_flow = $this->settings['checkout_flow'] ?? 'embedded';
+		$this->title                          = $this->get_option( 'title' );
+		$this->enabled                        = $this->get_option( 'enabled' );
+		$this->checkout_flow                  = $this->settings['checkout_flow'] ?? 'embedded';
+		$this->payment_gateway_icon           = $this->settings['payment_gateway_icon'] ?? 'default';
+		$this->payment_gateway_icon_max_width = $this->settings['payment_gateway_icon_max_width'] ?? '145';
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 
@@ -75,9 +77,20 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon_src   = 'https://cdn.dibspayment.com/logo/checkout/combo/horiz/DIBS_checkout_kombo_horizontal_04.png';
-		$icon_width = '145';
-		$icon_html  = '<img src="' . $icon_src . '" alt="Nets - Payments made easy" style="max-width:' . $icon_width . 'px"/>';
+
+		if ( empty( $this->payment_gateway_icon ) ) {
+			return;
+		}
+
+		if ( 'default' === strtolower( $this->payment_gateway_icon ) ) {
+			$icon_src   = 'https://cdn.dibspayment.com/logo/checkout/combo/horiz/DIBS_checkout_kombo_horizontal_04.png';
+			$icon_width = '145';
+		} else {
+			$icon_src   = $this->payment_gateway_icon;
+			$icon_width = $this->payment_gateway_icon_max_width;
+		}
+
+		$icon_html = '<img src="' . $icon_src . '" alt="Nets - Payments made easy" style="max-width:' . $icon_width . 'px"/>';
 		return apply_filters( 'wc_dibs_easy_icon_html', $icon_html );
 	}
 

--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -175,7 +175,7 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 
 		if ( array_key_exists( 'refundId', $response ) ) { // Payment success
 			// Translators: Nets refund ID.
-			$order->add_order_note( sprintf( __( 'Refund made in Nets Easy with refund ID %s. Reason: %s', 'dibs-easy-for-woocommerce' ), $response['refundId'], $reason ) ); // phpcs:ignore
+			$order->add_order_note( sprintf( __( 'Refund made in Nets Easy with refund ID %s.', 'dibs-easy-for-woocommerce' ), $response['refundId'] ) ); // phpcs:ignore
 
 			return true;
 		}

--- a/classes/class-nets-easy-subscriptions.php
+++ b/classes/class-nets-easy-subscriptions.php
@@ -67,8 +67,8 @@ class Nets_Easy_Subscriptions {
 		}
 
 		// Checks if this is a DIBS subscription payment method change.
-		$key                   = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
-		$change_payment_method = filter_input( INPUT_GET, 'change_payment_method', FILTER_SANITIZE_STRING );
+		$key                   = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$change_payment_method = filter_input( INPUT_GET, 'change_payment_method', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! empty( $key ) && ! empty( $change_payment_method ) ) {
 			$order_id = wc_get_order_id_by_order_key( sanitize_key( $key ) );
 			if ( $order_id ) {
@@ -140,9 +140,9 @@ class Nets_Easy_Subscriptions {
 	 * Handles subscription payment method change.
 	 */
 	public function dibs_payment_method_changed() {
-		$dibs_action = filter_input( INPUT_GET, 'dibs-action', FILTER_SANITIZE_STRING );
-		$order_id    = filter_input( INPUT_GET, 'wc-subscription-id', FILTER_SANITIZE_STRING );
-		$payment_id  = filter_input( INPUT_GET, 'paymentid', FILTER_SANITIZE_STRING );
+		$dibs_action = filter_input( INPUT_GET, 'dibs-action', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$order_id    = filter_input( INPUT_GET, 'wc-subscription-id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$payment_id  = filter_input( INPUT_GET, 'paymentid', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $dibs_action ) && 'subs-payment-changed' === $dibs_action && ! empty( $order_id ) && ! empty( $payment_id ) ) {
 			$response = Nets_Easy()->api->get_nets_easy_order( $payment_id );
@@ -410,7 +410,7 @@ class Nets_Easy_Subscriptions {
 	public function save_dibs_recurring_token_update( $post_id, $post ) {
 		$order = wc_get_order( $post_id );
 		if ( 'shop_subscription' === $order->get_type() && get_post_meta( $order->get_id(), '_dibs_recurring_token' ) ) {
-			$dibs_recurring_token = filter_input( INPUT_POST, '_dibs_recurring_token', FILTER_SANITIZE_STRING );
+			$dibs_recurring_token = filter_input( INPUT_POST, '_dibs_recurring_token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $dibs_recurring_token ) ) {
 				update_post_meta( $post_id, '_dibs_recurring_token', $dibs_recurring_token );
 			}

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -260,9 +260,16 @@ abstract class Nets_Easy_Request {
 		$title  = $this->log_title;
 		$code   = wp_remote_retrieve_response_code( $response );
 
-		$body     = json_decode( $response['body'], true );
-		$order_id = $body['paymentId'] ?? $body['payment']['paymentId'] ?? null;
-		$log      = Nets_Easy_Logger::format_log( $order_id, $method, $title, $request_args, $request_url, $response, $code );
+		$body = json_decode( $response['body'], true );
+
+		// Set payment id for reference iin log.
+		if ( ! empty( $this->payment_id ) ) {
+			$order_id = $this->payment_id;
+		} else {
+			$order_id = $body['paymentId'] ?? $body['payment']['paymentId'] ?? null;
+		}
+
+		$log = Nets_Easy_Logger::format_log( $order_id, $method, $title, $request_args, $request_url, $response, $code );
 		Nets_Easy_Logger::log( $log );
 	}
 }

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -66,6 +66,31 @@ class Nets_Easy_Cart_Helper {
 			$items[] = $gift_card;
 		}
 
+		// Smart coupons.
+		if ( ! empty( WC()->cart->get_coupons() ) ) {
+			foreach ( WC()->cart->get_coupons() as $coupon ) {
+				if ( 'smart_coupon' === $coupon->get_discount_type() ) {
+
+					$coupon_amount = intval( round( ( $coupon->get_amount() * 100 ) * -1 ) );
+					$label         = apply_filters( 'nets_smart_coupon_gift_card_label', esc_html( __( 'Gift card:', 'dibs-easy-for-woocommerce' ) . ' ' . $coupon->get_code() ), $coupon );
+					$giftcard_sku  = apply_filters( 'nets_smart_coupon_gift_card_sku', esc_html( $coupon->get_id() ), $coupon );
+					$gift_card     = array(
+						'reference'        => $giftcard_sku,
+						'name'             => $label,
+						'quantity'         => 1,
+						'unitPrice'        => $coupon_amount,
+						'taxRate'          => 0,
+						'grossTotalAmount' => $coupon_amount,
+						'netTotalAmount'   => $coupon_amount,
+						'taxAmount'        => 0,
+						'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
+					);
+
+					$items[] = $gift_card;
+				}
+			}
+		}
+
 		return $items;
 	}
 

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -49,7 +49,7 @@ class Nets_Easy_Cart_Helper {
 			foreach ( WC()->cart->applied_gift_cards as $coupon_key => $code ) {
 				$coupon_amount = isset( WC()->cart->applied_gift_cards_amounts[ $code ] ) ? - WC()->cart->applied_gift_cards_amounts[ $code ] * 100 : 0;
 				$label         = apply_filters( 'yith_ywgc_cart_totals_gift_card_label', esc_html( __( 'Gift card:', 'yith-woocommerce-gift-cards' ) . ' ' . $code ), $code );
-				$giftcard_sku  = apply_filters( 'nets_yith_gift_card_sku', esc_html( __( 'giftcard', 'dibs-easy-for-woocommerce' ) ), $code );
+				$giftcard_sku  = apply_filters( 'nets_yith_gift_card_sku', esc_html( $code ), $code );
 
 				$gift_card = array(
 					'reference'        => $giftcard_sku,

--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -51,6 +51,7 @@ class Nets_Easy_Checkout_Helper {
 			$order                                   = wc_get_order( $order_id );
 			$checkout['returnUrl']                   = add_query_arg( 'easy_confirm', 'yes', $order->get_checkout_order_received_url() );
 			$checkout['integrationType']             = 'HostedPaymentPage';
+			$checkout['cancelUrl']                   = 'admin' === $order->get_created_via() ? $order->get_checkout_payment_url() : wc_get_checkout_url();
 			$checkout['merchantHandlesConsumerData'] = true;
 			$checkout['shipping']['countries']       = array();
 			$checkout['shipping']['merchantHandlesShippingCost'] = false;

--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -26,6 +26,7 @@ class Nets_Easy_Checkout_Helper {
 	 */
 	public static function get_checkout( $checkout_flow = 'embedded', $order_id = null ) {
 		$dibs_settings = get_option( 'woocommerce_dibs_easy_settings' );
+		$auto_capture  = $dibs_settings['auto_capture'] ?? 'no';
 
 		$checkout = array(
 			'termsUrl' => wc_get_page_permalink( 'terms' ),
@@ -76,6 +77,12 @@ class Nets_Easy_Checkout_Helper {
 				break;
 			default:
 				$checkout['consumerType']['supportedTypes'] = array( 'B2B' );
+		}
+
+		// Capture transaction directly when reservation has been accepted?
+		// https://developers.nets.eu/nets-easy/en-EU/api/payment-v1/#v1-payments-post-body-checkout-charge.
+		if ( 'yes' === $auto_capture ) {
+			$checkout['charge'] = true;
 		}
 
 		return $checkout;

--- a/classes/requests/helpers/class-nets-easy-notification-helper.php
+++ b/classes/requests/helpers/class-nets-easy-notification-helper.php
@@ -35,8 +35,9 @@ class Nets_Easy_Notification_Helper {
 	public static function get_web_hooks() {
 		$web_hooks = array();
 
-		// Only set web hooks if host is not local (127.0.0.1 or ::1).
-		if ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) || isset( $_SERVER['HTTP_HOST'] ) && 'localhost' === substr( $_SERVER['HTTP_HOST'], 0, 9 ) ) {
+		// Do not send webhook url if this site is declared as a local environment via wp_get_environment_type().
+		// Read more about wp_get_environment_type https://developer.wordpress.org/reference/functions/wp_get_environment_type/.
+		if ( function_exists( 'wp_get_environment_type' ) && apply_filters( 'nets_easy_environment_without_public_url', 'local' ) === wp_get_environment_type() ) {
 			return $web_hooks;
 		} else {
 			$web_hooks[] = array(

--- a/classes/requests/helpers/class-nets-easy-order-items-helper.php
+++ b/classes/requests/helpers/class-nets-easy-order-items-helper.php
@@ -205,6 +205,37 @@ class Nets_Easy_Order_Items_Helper {
 			}
 		}
 
+		// Smart coupons.
+		if ( ! empty( $order->get_items( 'coupon' ) ) ) {
+			foreach ( $order->get_items( 'coupon' ) as $item_id => $item ) {
+
+				$code          = ( is_object( $item ) && is_callable( array( $item, 'get_name' ) ) ) ? $item->get_name() : trim( $item['name'] );
+				$coupon        = new WC_Coupon( $code );
+				$discount_type = $coupon->get_discount_type();
+				$discount      = ( is_object( $item ) && is_callable( array( $item, 'get_discount' ) ) ) ? $item->get_discount() : $item['discount_amount'];
+
+				if ( 'smart_coupon' === $discount_type && ! empty( $discount ) ) {
+
+					$coupon_amount = intval( round( ( $discount * 100 ) * -1 ) );
+					$label         = apply_filters( 'nets_smart_coupon_gift_card_label', esc_html( __( 'Gift card:', 'dibs-easy-for-woocommerce' ) . ' ' . $coupon->get_code() ), $coupon );
+					$giftcard_sku  = apply_filters( 'nets_smart_coupon_gift_card_sku', esc_html( $coupon->get_id() ), $coupon );
+					$gift_card     = array(
+						'reference'        => $giftcard_sku,
+						'name'             => $label,
+						'quantity'         => 1,
+						'unitPrice'        => $coupon_amount,
+						'taxRate'          => 0,
+						'grossTotalAmount' => $coupon_amount,
+						'netTotalAmount'   => $coupon_amount,
+						'taxAmount'        => 0,
+						'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
+					);
+
+					$items[] = $gift_card;
+				}
+			}
+		}
+
 		return $items;
 	}
 }

--- a/classes/requests/helpers/class-nets-easy-order-items-helper.php
+++ b/classes/requests/helpers/class-nets-easy-order-items-helper.php
@@ -186,10 +186,14 @@ class Nets_Easy_Order_Items_Helper {
 
 		if ( ! empty( $yith_giftcards ) ) {
 			foreach ( $yith_giftcards as $yith_giftcard_code => $yith_giftcard_value ) {
+
+				$label        = apply_filters( 'yith_ywgc_cart_totals_gift_card_label', esc_html( __( 'Gift card:', 'yith-woocommerce-gift-cards' ) . ' ' . $yith_giftcard_code ), $yith_giftcard_code );
+				$giftcard_sku = apply_filters( 'nets_yith_gift_card_sku', esc_html( $yith_giftcard_code ), $code );
+
 				$yith_giftcard_value = $yith_giftcard_value * 100 * -1;
 				$items[]             = array(
-					'reference'        => 'gift_card',
-					'name'             => 'Gift card',
+					'reference'        => $giftcard_sku,
+					'name'             => $label,
 					'quantity'         => '1',
 					'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
 					'unitPrice'        => $yith_giftcard_value,

--- a/classes/requests/post/class-nets-easy-request-activate-order.php
+++ b/classes/requests/post/class-nets-easy-request-activate-order.php
@@ -28,8 +28,10 @@ class Nets_Easy_Request_Activate_Order extends Nets_Easy_Request_Post {
 	 */
 	public function __construct( $arguments ) {
 		parent::__construct( $arguments );
-		$this->log_title = 'Activate order';
-		$this->order_id  = $this->arguments['order_id'];
+		$this->log_title  = 'Activate order';
+		$this->order_id   = $this->arguments['order_id'];
+		$this->order      = wc_get_order( $this->order_id );
+		$this->payment_id = $this->order->get_transaction_id();
 	}
 
 	/**
@@ -38,9 +40,8 @@ class Nets_Easy_Request_Activate_Order extends Nets_Easy_Request_Post {
 	 * @return array
 	 */
 	protected function get_body() {
-		$order = wc_get_order( $this->order_id );
 		return array(
-			'amount'     => intval( round( $order->get_total() * 100 ) ),
+			'amount'     => intval( round( $this->order->get_total() * 100 ) ),
 			'orderItems' => Nets_Easy_Order_Items_Helper::get_items( $this->order_id ),
 		);
 	}
@@ -51,8 +52,6 @@ class Nets_Easy_Request_Activate_Order extends Nets_Easy_Request_Post {
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$order      = wc_get_order( $this->order_id );
-		$payment_id = $order->get_transaction_id();
-		return $this->endpoint . 'payments/' . $payment_id . '/charges';
+		return $this->endpoint . 'payments/' . $this->payment_id . '/charges';
 	}
 }

--- a/classes/requests/post/class-nets-easy-request-cancel-order.php
+++ b/classes/requests/post/class-nets-easy-request-cancel-order.php
@@ -28,8 +28,10 @@ class Nets_Easy_Request_Cancel_Order extends Nets_Easy_Request_Post {
 	 */
 	public function __construct( $arguments = array() ) {
 		parent::__construct( $arguments );
-		$this->log_title = 'Cancel order';
-		$this->order_id  = $arguments['order_id'];
+		$this->log_title  = 'Cancel order';
+		$this->order_id   = $arguments['order_id'];
+		$this->order      = wc_get_order( $this->order_id );
+		$this->payment_id = $this->order->get_transaction_id();
 	}
 
 	/**
@@ -38,13 +40,11 @@ class Nets_Easy_Request_Cancel_Order extends Nets_Easy_Request_Post {
 	 * @return array
 	 */
 	protected function get_body() {
-		$order = wc_get_order( $this->order_id );
 		return array(
-			'amount'     => intval( round( $order->get_total() * 100 ) ),
+			'amount'     => intval( round( $this->order->get_total() * 100 ) ),
 			'orderItems' => Nets_Easy_Order_Items_Helper::get_items( $this->order_id ),
 		);
 	}
-
 
 	/**
 	 * Get the request url.
@@ -52,7 +52,6 @@ class Nets_Easy_Request_Cancel_Order extends Nets_Easy_Request_Post {
 	 * @return string
 	 */
 	protected function get_request_url() {
-		$payment_id = get_post_meta( $this->order_id, '_dibs_payment_id', true );
-		return $this->endpoint . 'payments/' . $payment_id . '/cancels';
+		return $this->endpoint . 'payments/' . $this->payment_id . '/cancels';
 	}
 }

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.2.0
+ * Version:                 2.2.1
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.1.0
+ * WC tested up to:         7.2.0
  * Copyright:               © 2017-2022 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.2.0' );
+define( 'WC_DIBS_EASY_VERSION', '2.2.1' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.4.0
+ * WC tested up to:         7.5.1
  * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.2.0
+ * WC tested up to:         7.2.2
  * Copyright:               © 2017-2022 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.2.2
+ * Version:                 2.3.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.2.2' );
+define( 'WC_DIBS_EASY_VERSION', '2.3.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.2.1
+ * Version:                 2.2.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,8 +16,8 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.2.2
- * Copyright:               © 2017-2022 Krokedil AB.
+ * WC tested up to:         7.4.0
+ * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.2.1' );
+define( 'WC_DIBS_EASY_VERSION', '2.2.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.1.0
+ * Version:                 2.2.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.0.0
+ * WC tested up to:         7.1.0
  * Copyright:               © 2017-2022 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.1.0' );
+define( 'WC_DIBS_EASY_VERSION', '2.2.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -193,7 +193,6 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 	$payment_id    = get_post_meta( $order_id, '_dibs_payment_id', true );
 	$settings      = get_option( 'woocommerce_dibs_easy_settings' );
 	$checkout_flow = $settings['checkout_flow'] ?? 'embedded';
-	$auto_capture  = $settings['auto_capture'] ?? 'no';
 
 	if ( null === $payment_id ) {
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
@@ -229,7 +228,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 			update_post_meta( $order_id, 'dibs_customer_card', $request['payment']['paymentDetails']['cardDetails']['maskedPan'] );
 		}
 
-		if ( 'A2A' === $request['payment']['paymentDetails']['paymentType'] ) {
+		if ( isset( $request['payment']['charges'][0]['chargeId'] ) && ! empty( $request['payment']['charges'][0]['chargeId'] ) ) {
 			// Get the DIBS order charge ID.
 			$dibs_charge_id = $request['payment']['charges'][0]['chargeId'];
 			update_post_meta( $order_id, '_dibs_charge_id', $dibs_charge_id );
@@ -242,9 +241,6 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 		}
 		$order->payment_complete( $payment_id );
 
-		if ( 'yes' === $auto_capture ) {
-			Nets_Easy()->order_management->dibs_order_completed( $order_id );
-		}
 	} else {
 		// Purchase not finalized in DIBS.
 		// If this is a redirect checkout flow let's redirect the customer to cart page.

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -174,8 +174,9 @@ function wc_dibs_get_locale() {
  * @param string $name Name to be cleaned.
  */
 function wc_dibs_clean_name( $name ) {
-	$regex = '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9\x{00A1}-\x{00AC}\x{00AE}-\x{00FF}\x{0100}-\x{017F}\x{0180}-\x{024F}\x{0250}-\x{02AF}\x{02B0}-\x{02FF}\x{0300}-\x{036F}\s]+/u';
-	$name  = mb_ereg_replace( $regex, '', $name );
+	$not_allowed_characters = array( '<', '>', '\\', '"', '&' );
+	$name                   = wp_strip_all_tags( $name );
+	$name                   = str_replace( $not_allowed_characters, '', $name );
 
 	return substr( $name, 0, 128 );
 }

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -329,3 +329,35 @@ function dibs_easy_print_error_message( $wp_error ) {
 	}
 }
 
+/**
+ * Finds an Order ID based on a payment ID (the Nets order number).
+ *
+ * @param string $payment_id Nets order number saved as Payment ID in WC order.
+ * @return int The ID of an order, or 0 if the order could not be found.
+ */
+function nets_easy_get_order_id_by_purchase_id( $payment_id ) {
+	$query_args = array(
+		'fields'      => 'ids',
+		'post_type'   => wc_get_order_types(),
+		'post_status' => array_keys( wc_get_order_statuses() ),
+		'meta_key'    => '_dibs_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'meta_value'  => sanitize_text_field( wp_unslash( $payment_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		'date_query'  => array(
+			array(
+				'after' => '30 day ago',
+			),
+		),
+	);
+
+	$orders = get_posts( $query_args );
+
+	if ( $orders ) {
+		$order_id = $orders[0];
+	} else {
+		$order_id = 0;
+	}
+
+	return $order_id;
+}
+
+

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -39,7 +39,7 @@ function dibs_easy_maybe_create_order() {
 	}
 	// store payment id.
 	$session->set( 'dibs_payment_id', $dibs_easy_order['paymentId'] );
-	$session->set( 'dibs_currency', get_woocommerce_currency() );
+	$session->set( 'nets_easy_currency', get_woocommerce_currency() );
 	$session->set( 'nets_easy_last_update_hash', $cart->get_cart_hash() );
 	$session->set( 'dibs_cart_contains_subscription', get_dibs_cart_contains_subscription() );
 	// Set a transient for this paymentId. It's valid in DIBS system for 20 minutes.
@@ -109,8 +109,8 @@ function wc_dibs_unset_sessions() {
 		if ( WC()->session->get( 'dibs_customer_order_note' ) ) {
 			WC()->session->__unset( 'dibs_customer_order_note' );
 		}
-		if ( WC()->session->get( 'dibs_currency' ) ) {
-			WC()->session->__unset( 'dibs_currency' );
+		if ( WC()->session->get( 'nets_easy_currency' ) ) {
+			WC()->session->__unset( 'nets_easy_currency' );
 		}
 
 		if ( WC()->session->get( 'dibs_cart_contains_subscription' ) ) {

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -175,7 +175,7 @@ function wc_dibs_get_locale() {
  */
 function wc_dibs_clean_name( $name ) {
 	$regex = '/[^!#$%()*+,-.\/:;=?@\[\]\\\^_`{}|~a-zA-Z0-9\x{00A1}-\x{00AC}\x{00AE}-\x{00FF}\x{0100}-\x{017F}\x{0180}-\x{024F}\x{0250}-\x{02AF}\x{02B0}-\x{02FF}\x{0300}-\x{036F}\s]+/u';
-	$name  = preg_replace( $regex, '', $name );
+	$name  = mb_ereg_replace( $regex, '', $name );
 
 	return substr( $name, 0, 128 );
 }

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -203,6 +203,17 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 
 	$request = Nets_Easy()->api->get_nets_easy_order( $payment_id, $order_id );
 
+	if ( is_wp_error( $request ) ) {
+		$order->add_order_note(
+			sprintf(
+				/* translators: %s: Error message */
+				__( 'Nets Easy: Error when confirming order: %s', 'dibs-easy-for-woocommerce' ),
+				$request->get_error_message()
+			)
+		);
+		return;
+	}
+
 	if ( isset( $request['payment']['summary']['reservedAmount'] ) || isset( $request['payment']['summary']['chargedAmount'] ) || isset( $request['payment']['subscription']['id'] ) ) {
 
 		do_action( 'dibs_easy_process_payment', $order_id, $request );

--- a/includes/nets-easy-settings.php
+++ b/includes/nets-easy-settings.php
@@ -93,6 +93,12 @@ return apply_filters(
 			'description' => __( 'This text will be added to your customers order confirmation email.', 'dibs-easy-for-woocommerce' ),
 			'default'     => '',
 		),
+		'email_nets_payment_data'      => array(
+			'title'   => __( 'Email payment data', 'dibs-easy-for-woocommerce' ),
+			'type'    => 'checkbox',
+			'label'   => __( 'Add Nets payment data to order confirmation email.', 'dibs-easy-for-woocommerce' ),
+			'default' => 'no',
+		),
 		'dibs_manage_orders'           => array(
 			'title'   => __( 'Manage orders', 'dibs-easy-for-woocommerce' ),
 			'type'    => 'checkbox',

--- a/includes/nets-easy-settings.php
+++ b/includes/nets-easy-settings.php
@@ -154,5 +154,19 @@ return apply_filters(
 			'default'     => 'subscribe',
 			'desc_tip'    => false,
 		),
+		'payment_gateway_icon'         => array(
+			'title'       => __( 'Payment gateway icon', 'dibs-easy-for-woocommerce' ),
+			'type'        => 'text',
+			'description' => __( 'Enter an URL to the icon you want to display for the payment method. Use <i>default</i> to display the default Nets logo. Leave blank to not show an icon at all.', 'dibs-easy-for-woocommerce' ),
+			'default'     => 'default',
+			'desc_tip'    => false,
+		),
+		'payment_gateway_icon_width'   => array(
+			'title'       => __( 'Payment gateway icon width', 'dibs-easy-for-woocommerce' ),
+			'type'        => 'number',
+			'description' => __( 'Specify the max width (in px) of the payment gateway icon.', 'dibs-easy-for-woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		),
 	)
 );

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 7.0
 WC requires at least: 5.0.0
-WC tested up to: 7.0.0
-Stable tag: 2.1.0
+WC tested up to: 7.1.0
+Stable tag: 2.2.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,14 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2022.11.09    - version 2.2.0 =
+* Feature       - Adds customer name and address in create session request to Nets (if they exist in Woo) for embedded checkout.
+* Tweak         - Sends cancel url in payment requests to Nets.
+* Fix           - Better handling of finalizing purchase in WooCommerce if customer is redirected back to store in another browser than what the purchase started with.
+* Fix           - Use mb_ereg_replace instead of preg_replace to avoid certain characters not approved by Nets in product and shipping names.
+* Fix           - Save recurring token correctly for uncheduled subscriptions when changing/updating payment method from My account page.
+* Fix           - Adds a unique script name when enqueuing checkout script. To avoid conflicts with other payment plugins.
+
 = 2022.09.07    - version 2.1.0 =
 * Feature       - Adds support for Nets Easy unscheduled subscriptions. Can only be activated via filter nets_easy_subscription_type for now.
 * Fix           - Fix bug not possible to update recurring token from subscriptions page.

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.0
 Tested up to: 6.1.1
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.2.2
-Stable tag: 2.2.1
+WC tested up to: 7.4.0
+Stable tag: 2.2.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,12 +50,16 @@ Available for merchants in Denmark, Sweden and Norway.
 For help setting up and configuring Nets Easy for WooCommerce please refer to our [documentation](http://docs.krokedil.com/documentation/nets-easy-for-woocommerce/).
 
 = Are there any specific requirements? =
-* WooCommerce 3.5 or newer is required.
-* PHP 5.6 or higher is required.
+* WooCommerce 5.0 or newer is required.
+* PHP 7.2 or higher is required.
 * A SSL Certificate is required.
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.02.28    - version 2.2.2 =
+* Tweak         - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
+* fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
+
 = 2022.12.14    - version 2.2.1 =
 * Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.
 * Fix           - Avoid fatal error in confirmation sequence if request to Nets fails. 

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
 Tested up to: 6.1
-Requires PHP: 7.0
+Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.1.0
-Stable tag: 2.2.0
+WC tested up to: 7.2.0
+Stable tag: 2.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,11 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2022.12.14    - version 2.2.1 =
+* Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.
+* Fix           - Avoid fatal error in confirmation sequence if request to Nets fails. 
+* Fix           - Avoid fatal error in process payment sequence (redirect checkout flow) if request to Nets fails.
+
 = 2022.11.09    - version 2.2.0 =
 * Feature       - Adds customer name and address in create session request to Nets (if they exist in Woo) for embedded checkout.
 * Tweak         - Sends cancel url in payment requests to Nets.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.1.1
+Tested up to: 6.2
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.4.0
+WC tested up to: 7.5.1
 Stable tag: 2.2.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -61,7 +61,7 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * Tweak         - Sends cancel url in payment requests to Nets.
 * Fix           - Better handling of finalizing purchase in WooCommerce if customer is redirected back to store in another browser than what the purchase started with.
 * Fix           - Use mb_ereg_replace instead of preg_replace to avoid certain characters not approved by Nets in product and shipping names.
-* Fix           - Save recurring token correctly for uncheduled subscriptions when changing/updating payment method from My account page.
+* Fix           - Save recurring token correctly for unscheduled subscriptions when changing/updating payment method from My account page.
 * Fix           - Adds a unique script name when enqueuing checkout script. To avoid conflicts with other payment plugins.
 
 = 2022.09.07    - version 2.1.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 == CHANGELOG ==
 = 2023.02.28    - version 2.2.2 =
 * Tweak         - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
-* fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
+* Fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.
 
 = 2022.12.14    - version 2.2.1 =
 * Tweak         - Improvement in logic regarding product & shipping method name cleaning. We now remove specific characters not supported by Nets.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.1
+Tested up to: 6.1.1
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.2.0
+WC tested up to: 7.2.2
 Stable tag: 2.2.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.2
 Requires PHP: 7.2
 WC requires at least: 5.0.0
 WC tested up to: 7.5.1
-Stable tag: 2.2.2
+Stable tag: 2.3.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,21 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.04.13    - version 2.3.0 =
+* Feature       - Adds settings for custom payment gateway icon.
+* Feature       - Add setting to control if Nets payment data (payment method, payment ID and masked card number) should be added to customer email.
+* Feature       - Adds support for gift cards via Smart coupons plugin.
+* Feature       - Adds filter nets_easy_ignored_checkout_fields to allow others to alter which fields appear under additional fields (thanks @oxyc).
+* Tweak         - Reload checkout page and try to send update request again to Nets if response code is 409 on an update.
+* Tweak         - Change logic for auto capture. We now send charge = true in the create request and look for a charge id in payment confirmation, instead of making an activation request in payment confirmation sequenze.
+* Tweak         - Improved logic for enqueuing of js files to avoid creation of Nets payment ID when checkout page is rendered but Nets Easy isn't the selected payment gateway.
+* Tweak         - Change sku sent for YITH giftcard. Now we use giftcard code to allow multiple cift card used n one order. 
+* Tweak         - Tweak to YITH giftcard name sent to Nets, use the format Gift card: {gifdcard_code}.
+* Tweak         - Adds payment ID to log for charge order, cancel order and update cart requests.
+* Tweak         - Tweak in refund message logged as order note. Reason not needed.
+* Fix           - PHP 8.1 deprecated notice fix.
+* Fix           - Reload checkout page if cart doesn't need payment for embedded checkoutflow. So that regular Woo checkout template is used instead.
+
 = 2023.02.28    - version 2.2.2 =
 * Tweak         - Do not send webhook url to Nets if the site is declared as a local environment via wp_get_environment_type(). Previously this was checked via $_SERVER['REMOTE_ADDR'] & $_SERVER['HTTP_HOST'].
 * Fix           - Improved multi currency support. Creates new Nets payment ID if currency is changed mid session.


### PR DESCRIPTION
* Feature - Adds settings for custom payment gateway icon.
* Feature - Add setting to control if Nets payment data (payment method, payment ID and masked card number) should be added to customer email.
* Feature - Adds support for gift cards via Smart coupons plugin.
* Feature - Adds filter nets_easy_ignored_checkout_fields to allow others to alter which fields appear under additional fields (thanks @oxyc).
* Tweak - Reload checkout page and try to send update request again to Nets if response code is 409 on an update.
* Tweak - Change logic for auto capture. We now send charge = true in the create request and look for a charge id in payment confirmation, instead of making an activation request in payment confirmation sequenze.
* Tweak - Improved logic for enqueuing of js files to avoid creation of Nets payment ID when checkout page is rendered but Nets Easy isn't the selected payment gateway.
* Tweak - Change sku sent for YITH giftcard. Now we use giftcard code to allow multiple cift card used n one order. 
* Tweak - Tweak to YITH giftcard name sent to Nets, use the format Gift card: {gifdcard_code}.
* Tweak - Adds payment ID to log for charge order, cancel order and update cart requests.
* Tweak - Tweak in refund message logged as order note. Reason not needed.
* Fix - PHP 8.1 deprecated notice fix.
* Fix - Reload checkout page if cart doesn't need payment for embedded checkoutflow. So that regular Woo checkout template is used instead.