### PR TITLE
Version 2.4.0

### DIFF
--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -293,14 +293,9 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 		if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
 
 			// Update order number in DIBS system if this is the embedded checkout flow.
-			$payment_id = get_post_meta( $order_id, '_dibs_payment_id', true );
-			update_post_meta( $order_id, '_dibs_payment_id', WC()->session->get( 'dibs_payment_id' ) );
-			$response = Nets_Easy()->api->update_nets_easy_order_reference( WC()->session->get( 'dibs_payment_id' ), $order_id );
-			if ( is_wp_error( $response ) ) {
-				return array(
-					'result' => 'error',
-				);
-			}
+			$payment_id = WC()->session->get( 'dibs_payment_id' );
+			update_post_meta( $order_id, '_dibs_payment_id', $payment_id );
+
 			return array(
 				'result'   => 'success',
 				'redirect' => add_query_arg( 'easy_confirm', 'yes', $order->get_checkout_order_received_url() ),

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -62,8 +62,9 @@ class Nets_Easy_Cart_Helper {
 					'taxAmount'        => 0,
 					'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
 				);
+
+				$items[] = $gift_card;
 			}
-			$items[] = $gift_card;
 		}
 
 		// Smart coupons.

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.3.2
+ * Version:                 2.4.0
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.7.0
+ * WC tested up to:         7.7.2
  * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.3.2' );
+define( 'WC_DIBS_EASY_VERSION', '2.4.0' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.6.0
+ * WC tested up to:         7.7.0
  * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.3.1
+ * Version:                 2.3.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.3.1' );
+define( 'WC_DIBS_EASY_VERSION', '2.3.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.2
 Requires PHP: 7.2
 WC requires at least: 5.0.0
 WC tested up to: 7.6.0
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,9 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.04.26    - version 2.3.2 =
+* Fix           - New improvement in logger logic, to avoid potential PHP issue with some plugins.
+
 = 2023.04.20    - version 2.3.1 =
 * Tweak         - Remove maybeChangeToDibsEasy logic from nets-easy-for-woocommerce.js. This has been moved to nets-easy-utility.js.
 * Fix           - Avoid division by zero issue if fee is 0.

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.2.1
+Tested up to: 6.2.2
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.7.0
-Stable tag: 2.3.2
+WC tested up to: 7.7.2
+Stable tag: 2.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -56,6 +56,10 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.06.05    - version 2.4.0 =
+* Tweak         - Sand WooCommerce order number as order reference to Nets later in the process (when payment is confirmed in Woo) due to changes in Nets API.
+* Fix           - Improvements in logic to allow multiple YITH giftcards in same order.
+
 = 2023.04.26    - version 2.3.2 =
 * Fix           - New improvement in logger logic, to avoid potential PHP issue with some plugins.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.2.1
 Requires PHP: 7.2
 WC requires at least: 5.0.0
-WC tested up to: 7.6.0
+WC tested up to: 7.7.0
 Stable tag: 2.3.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
* Tweak - Sand WooCommerce order number as order reference to Nets later in the process (when payment is confirmed in Woo) due to changes in Nets API.
* Fix - Improvements in logic to allow multiple YITH giftcards in same order.