### PR TITLE
Fix payment form not appearing on block-based themes

### DIFF
--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -32,7 +32,7 @@ class Nets_Easy_Assets {
 
 		if ( 'embedded' === $this->checkout_flow ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_js' ), 10 );
-			add_action( 'wc_dibs_before_checkout_form', array( $this, 'localize_and_enqueue_checkout_script' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'localize_and_enqueue_checkout_script' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_css' ), 10 );
 		}
 

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -31,8 +31,11 @@ class Nets_Easy_Assets {
 		$this->checkout_flow = $this->settings['checkout_flow'] ?? '';
 
 		if ( 'embedded' === $this->checkout_flow ) {
-			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_js' ), 10 );
-			add_action( 'wp_enqueue_scripts', array( $this, 'localize_and_enqueue_checkout_script' ) );
+
+			/* For block-based themes, the template process is processed BEFORE the `wp_enqueue_script`. We need to enqueue the scripts in 'dibs_load_js' before the localized script is enqueued which depends on the former. The `init` hook cannot be used since `is_checkout` always returns false. With `template_redirect`, `is_checkout` returns the correct value, and is processed before the localization script is enqueued. */
+			add_action( 'template_redirect', array( $this, 'dibs_load_js' ), 10 );
+			add_action( 'wc_dibs_before_checkout_form', array( $this, 'localize_and_enqueue_checkout_script' ) );
+
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_load_css' ), 10 );
 		}
 


### PR DESCRIPTION
The localization relies on the `nets-easy-checkout` script. However, the current action on which it is enqueued, `wc_dibs_before_checkout_form`, occurs too early in the process, specifically during the templating stage. At this point, the necessary `dibs_load_js` action has not yet been triggered. Since we depend on the localized variables provided by `dibs_load_js`, the checkout fails to initialize properly.

It appears that WooCommerce has altered the order in which these actions are triggered. In block-based themes, the template actions occur before the scripts are enqueued. However, in classical themes, the order is reversed, with the scripts being enqueued before the template actions.

# UPDATE

For block-based themes, the template process is processed BEFORE the `wp_enqueue_script`. We need to enqueue the scripts in 'dibs_load_js' before the localized script is enqueued which depends on the former. The `init` hook cannot be used since `is_checkout` always returns false. With `template_redirect`, `is_checkout` returns the correct value, and is processed before the localization script is enqueued.