### PR TITLE
Version 2.5.2

### DIFF
--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -16,6 +16,7 @@ class Nets_Easy_Checkout {
 	 */
 	public function __construct() {
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_nets_easy_order' ), 999999 );
+		add_filter( 'allowed_redirect_hosts', array( $this, 'extend_allowed_domains_list' ) );
 	}
 
 	/**
@@ -114,4 +115,17 @@ class Nets_Easy_Checkout {
 			WC()->session->set( 'nets_easy_last_update_hash', $cart_hash );
 		}
 	}
+
+	/**
+	 * Add Nets Easy hosted payment page as allowed external url for wp_safe_redirect.
+	 * We do this because WooCommerce Subscriptions use wp_safe_redirect when processing a payment method change request (from v5.1.0).
+	 *
+	 * @param array $hosts Domains that are allowed when wp_safe_redirect is used.
+	 * @return array
+	 */
+	public function extend_allowed_domains_list( $hosts ) {
+		$hosts[] = 'checkout.dibspayment.eu';
+		return $hosts;
+	}
+
 } new Nets_Easy_Checkout();

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nets Easy for WooCommerce
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://www.dibspayment.com/" target="_blank">Nets Easy</a> checkout for WooCommerce.
- * Version:                 2.5.1
+ * Version:                 2.5.2
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.0.0
- * WC tested up to:         7.8.0
+ * WC tested up to:         7.9.0
  * Copyright:               © 2017-2023 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.5.1' );
+define( 'WC_DIBS_EASY_VERSION', '2.5.2' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets
 Requires at least: 5.0
 Tested up to: 6.2.2
-Requires PHP: 7.2
+Requires PHP: 7.3
 WC requires at least: 5.0.0
-WC tested up to: 7.8.0
-Stable tag: 2.5.1
+WC tested up to: 7.9.0
+Stable tag: 2.5.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,11 +51,14 @@ For help setting up and configuring Nets Easy for WooCommerce please refer to ou
 
 = Are there any specific requirements? =
 * WooCommerce 5.0 or newer is required.
-* PHP 7.2 or higher is required.
+* PHP 7.3 or higher is required.
 * A SSL Certificate is required.
 * This plugin integrates with Nets Easy. You need an agreement with Nets specific to the Nets Easy platform to use this plugin.
 
 == CHANGELOG ==
+= 2023.07.25    - version 2.5.2 =
+* Fix           - Solves issue with redirect to payment page when changing/updating subscription payment method. Add Nets Easy hosted payment page as allowed external url for wp_safe_redirect.
+
 = 2023.07.17    - version 2.5.1 =
 * Fix           - Blocked-based themes should now work as expected with the embedded checkout.
 


### PR DESCRIPTION
* Fix - Solves issue with redirect to payment page when changing/updating subscription payment method. Add Nets Easy hosted payment page as allowed external url for wp_safe_redirect.