### PR TITLE
Filter order reference

### DIFF
--- a/classes/requests/helpers/class-nets-easy-order-helper.php
+++ b/classes/requests/helpers/class-nets-easy-order-helper.php
@@ -35,7 +35,7 @@ class Nets_Easy_Order_Helper {
 				'shipping'  => array(
 					'costSpecified' => true,
 				),
-				'reference' => '1',
+				'reference' => apply_filters( 'nets_easy_embedded_order_reference', '1' ),
 			);
 		}
 


### PR DESCRIPTION
* Adds filter `nets_easy_embedded_order_reference` so initial order reference in embedded checkout flow can be tweaked by merchant.