### PR TITLE
Do not update merchant order reference for order pay

### DIFF
--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -160,15 +160,21 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 		// Regular purchase.
 		// Embedded flow.
 		if ( 'embedded' === $this->checkout_flow && ! is_wc_endpoint_url( 'order-pay' ) ) {
+			$order->update_meta_data( '_dibs_checkout_flow', 'embedded' );
+			$order->save();
 			// Save payment type, card details & run $order->payment_complete() if all looks good.
 			return $this->process_embedded_handler( $order_id );
 		}
 
 		// Overlay flow.
 		if ( 'overlay' === $this->checkout_flow && ! wp_is_mobile() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+			$order->update_meta_data( '_dibs_checkout_flow', 'overlay' );
+			$order->save();
 			return $this->process_overlay_handler( $order_id );
 		}
 
+		$order->update_meta_data( '_dibs_checkout_flow', 'redirect' );
+		$order->save();
 		return $this->process_redirect_handler( $order_id );
 	}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -236,6 +236,8 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 		}
 
 		// Update order reference if this is embedded checkout flow.
+		$_checkout_flow = $order->get_meta( '_dibs_checkout_flow' );
+		$checkout_flow  = ! empty( $_checkout_flow ) ? $_checkout_flow : $checkout_flow;
 		if ( 'embedded' === $checkout_flow ) {
 			$order_reference_response = Nets_Easy()->api->update_nets_easy_order_reference( $payment_id, $order_id );
 			if ( is_wp_error( $order_reference_response ) ) {


### PR DESCRIPTION
Currently, we retrieve the `$checkout_flow` directly from the settings, however, for order pay, we use the redirect flow. Thus the `$checkout_flow` is incorrectly set to 'embedded' which results in order reference update request which should not be issued for order pay.

By the time, we reach `wc_dibs_confirm_dibs_order`, we're no longer on the order-pay endpoint, and can no longer determine if it was an order pay purchase. Therefore, we have to save the checkout flow in the order meta data.