### PR TITLE
Add class properties for PHP 8.2 compatibility, Closes #236

### DIFF
--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -77,6 +77,41 @@ if ( ! class_exists( 'DIBS_Easy' ) ) {
 		public $order_management;
 
 		/**
+		 * Enable Payment Method Card
+		 *
+		 * @var $enable_payment_method_card
+		 */
+		public $enable_payment_method_card;
+
+		/**
+		 * Enable Payment Method Sofort payment.
+		 *
+		 * @var $enable_payment_method_sofort
+		 */
+		public $enable_payment_method_sofort;
+
+		/**
+		 * Enable Payment Method Trustly payment.
+		 *
+		 * @var $enable_payment_method_trustly
+		 */
+		public $enable_payment_method_trustly;
+
+		/**
+		 * Enable Payment Method Swish payment.
+		 *
+		 * @var $enable_payment_method_swish
+		 */
+		public $enable_payment_method_swish;
+
+		/**
+		 * Enable Payment Method Ratepay payment.
+		 *
+		 * @var $enable_payment_method_ratepay_sepa
+		 */
+		public $enable_payment_method_ratepay_sepa;
+
+		/**
 		 * DIBS_Easy constructor.
 		 */
 		public function __construct() {


### PR DESCRIPTION
- Add class properties to `DIBS_Easy` class to avoid PHP 8.2 deprecation messages.
-  Closes #236

<img width="1707" alt="Screenshot 2023-11-16 at 10 00 38" src="https://github.com/krokedil/dibs-easy-for-woocommerce/assets/16900754/5db303a8-dbb5-43d1-8e66-f8967ea6e753">
