### PR TITLE
Reload checkout when going back from overlay

### DIFF
--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -55,6 +55,7 @@ class Nets_Easy_Checkout_Helper {
 
 			if ( 'overlay' === $checkout_flow ) {
 				$return_url = add_query_arg( array( 'nets_reload' => 'true' ), $return_url );
+				$cancel_url = add_query_arg( array( 'nets_reload' => 'true' ), $cancel_url );
 			}
 
 			$checkout['returnUrl']                               = esc_url_raw( $return_url );


### PR DESCRIPTION
The logic for handling a reload already exists, but the parameter was missing in the cancel URL.

https://app.clickup.com/t/8695gar7f