### PR TITLE
Develop fix get order with w/o payment

### DIFF
--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -80,9 +80,9 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		if ( ! is_user_logged_in() && ( ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) || 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) ) {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found while trying to update the customer address.' );
-				return;
+				wp_send_json_error( 'Failed to update customer address. Payment ID missing.' );
 			}
+
 			$response = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 			if ( ! is_wp_error( $response ) ) {
 				$email = $response['payment']['consumer']['privatePerson']['email'];
@@ -152,8 +152,7 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		}
 
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found while attempting to get the Nexi order data.' );
-			return;
+			wp_send_json_error( 'Failed to get the Nexi order data. Payment ID missing.' );
 		}
 
 		// Prevent duplicate orders if payment complete event is triggered twice or if order already exist in Woo (via webhook).

--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -151,6 +151,7 @@ class Nets_Easy_Ajax extends WC_AJAX {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
 		}
 
+		if ( empty( $payment_id ) ) {
 			Nets_Easy_Logger::log( 'No payment ID found in the get order data request.' );
 			return;
 		}

--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -80,7 +80,8 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		if ( ! is_user_logged_in() && ( ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) || 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) ) {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found while trying to get customer email.' );
+				$session_id = WC()->session->get_session_cookie()[0];
+				Nets_Easy_Logger::log( 'No payment ID found while trying to get customer email for WooCommerce session ID: ' . $session_id );
 				return;
 			}
 			$response = Nets_Easy()->api->get_nets_easy_order( $payment_id );
@@ -152,7 +153,8 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		}
 
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found in the get order data request.' );
+			$session_id = WC()->session->get_session_cookie()[0];
+			Nets_Easy_Logger::log( 'No payment ID found in the get order data request for WooCommerce session ID: ' . $session_id );
 			return;
 		}
 

--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -79,7 +79,11 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		// If customer is not logged in and this is a subscription purchase - get customer email from DIBS.
 		if ( ! is_user_logged_in() && ( ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) || 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) ) {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
-			$response   = Nets_Easy()->api->get_nets_easy_order( $payment_id );
+			if ( empty( $payment_id ) ) {
+				Nets_Easy_Logger::log( 'No payment ID found while trying to get customer email.' );
+				return;
+			}
+			$response = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 			if ( ! is_wp_error( $response ) ) {
 				$email = $response['payment']['consumer']['privatePerson']['email'];
 				if ( email_exists( $email ) ) {
@@ -145,6 +149,10 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		$payment_id = filter_input( INPUT_POST, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( ! $payment_id ) {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
+		}
+
+			Nets_Easy_Logger::log( 'No payment ID found in the get order data request.' );
+			return;
 		}
 
 		// Prevent duplicate orders if payment complete event is triggered twice or if order already exist in Woo (via webhook).
@@ -221,7 +229,6 @@ class Nets_Easy_Ajax extends WC_AJAX {
 			self::prepare_cart_before_form_processing( $response['payment']['consumer']['shippingAddress']['country'] );
 			wp_send_json_success( $response );
 		}
-
 	}
 
 	/**
@@ -295,7 +302,6 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		Nets_Easy_Logger::log( $message );
 		wp_send_json_success();
 	}
-
 }
 
 Nets_Easy_Ajax::init();

--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -80,8 +80,7 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		if ( ! is_user_logged_in() && ( ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) || 'no' === get_option( 'woocommerce_enable_guest_checkout' ) ) ) {
 			$payment_id = WC()->session->get( 'dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				$session_id = WC()->session->get_session_cookie()[0];
-				Nets_Easy_Logger::log( 'No payment ID found while trying to get customer email for WooCommerce session ID: ' . $session_id );
+				Nets_Easy_Logger::log( 'No payment ID found while trying to update the customer address.' );
 				return;
 			}
 			$response = Nets_Easy()->api->get_nets_easy_order( $payment_id );
@@ -153,8 +152,7 @@ class Nets_Easy_Ajax extends WC_AJAX {
 		}
 
 		if ( empty( $payment_id ) ) {
-			$session_id = WC()->session->get_session_cookie()[0];
-			Nets_Easy_Logger::log( 'No payment ID found in the get order data request for WooCommerce session ID: ' . $session_id );
+			Nets_Easy_Logger::log( 'No payment ID found while attempting to get the Nexi order data.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -43,7 +43,7 @@ class Nets_Easy_Checkout {
 
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 		if ( empty( $payment_id ) ) {
-			wp_send_json_error( 'Failed to update the Nexi order. Payment ID missing.' );
+			return;
 		}
 
 		// Trigger get if the ajax event is among the approved ones.

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -43,6 +43,7 @@ class Nets_Easy_Checkout {
 
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 		if ( empty( $payment_id ) ) {
+			Nets_Easy_Logger::log( 'No payment ID found in the update order request.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -43,8 +43,7 @@ class Nets_Easy_Checkout {
 
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 		if ( empty( $payment_id ) ) {
-			$session_id = WC()->session->get_session_cookie()[0];
-			Nets_Easy_Logger::log( 'No payment ID found in the update order request for cart for WooCommerce session ID: ' . $session_id );
+			Nets_Easy_Logger::log( 'No payment ID found while attempting to update the Nexi order.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -43,8 +43,7 @@ class Nets_Easy_Checkout {
 
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found while attempting to update the Nexi order.' );
-			return;
+			wp_send_json_error( 'Failed to update the Nexi order. Payment ID missing.' );
 		}
 
 		// Trigger get if the ajax event is among the approved ones.

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -43,7 +43,8 @@ class Nets_Easy_Checkout {
 
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found in the update order request.' );
+			$session_id = WC()->session->get_session_cookie()[0];
+			Nets_Easy_Logger::log( 'No payment ID found in the update order request for cart for WooCommerce session ID: ' . $session_id );
 			return;
 		}
 

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -109,7 +109,8 @@ class Nets_Easy_Confirmation {
 		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found for customer redirected back to checkout.' );
+			$session_cookie = WC()->session->get_session_cookie()[0];
+			Nets_Easy_Logger::log( 'No payment ID found for customer redirected back to checkout for WooCommerce session ID: ' . $session_cookie );
 			return;
 		}
 

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -108,10 +108,6 @@ class Nets_Easy_Confirmation {
 
 		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( empty( $payment_id ) ) {
-			$payment_id = WC()->session->get( 'dibs_payment_id' );
-		}
-
-		if ( empty( $payment_id ) ) {
 			return;
 		}
 

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -109,8 +109,7 @@ class Nets_Easy_Confirmation {
 		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( empty( $payment_id ) ) {
-			$session_cookie = WC()->session->get_session_cookie()[0];
-			Nets_Easy_Logger::log( 'No payment ID found for customer redirected back to checkout for WooCommerce session ID: ' . $session_cookie );
+			Nets_Easy_Logger::log( 'No payment ID found on customer redirect back to checkout.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -107,9 +107,11 @@ class Nets_Easy_Confirmation {
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
 
 		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		if ( empty( $payment_id ) ) {
+			$payment_id = WC()->session->get( 'dibs_payment_id' );
+		}
 
 		if ( empty( $payment_id ) ) {
-			Nets_Easy_Logger::log( 'No payment ID found on customer redirect back to checkout.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -109,6 +109,7 @@ class Nets_Easy_Confirmation {
 		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( empty( $payment_id ) ) {
+			Nets_Easy_Logger::log( 'No payment ID found for customer redirected back to checkout.' );
 			return;
 		}
 

--- a/classes/class-nets-easy-order-management.php
+++ b/classes/class-nets-easy-order-management.php
@@ -75,6 +75,7 @@ class Nets_Easy_Order_Management {
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
 				Nets_Easy_Logger::log( 'No payment ID found in the order completed request for WooCommerce order number: ' . $wc_order->get_order_number() );
+				$this->fetching_order_failed( $wc_order, true, 'No payment ID found in the order completed request for WooCommerce order number: ' . $wc_order->get_order_number() );
 				return;
 			}
 
@@ -125,6 +126,7 @@ class Nets_Easy_Order_Management {
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
 				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request for WooCommerce order number: ' . $wc_order->get_order_number() );
+				$this->fetching_order_failed( $wc_order, true, 'No payment ID found in the order canceled request for WooCommerce order number: ' . $wc_order->get_order_number() );
 				return;
 			}
 

--- a/classes/class-nets-easy-order-management.php
+++ b/classes/class-nets-easy-order-management.php
@@ -71,8 +71,15 @@ class Nets_Easy_Order_Management {
 				$wc_order->add_order_note( sprintf( __( 'No charge needed in Nexi system since the order total is %s.', 'dibs-easy-for-woocommerce' ), $wc_order->get_total() ) );
 				return;
 			}
+
+			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
+			if ( empty( $payment_id ) ) {
+				Nets_Easy_Logger::log( 'No payment ID found in the order completed request.' );
+				return;
+			}
+
 			// Get Nexi Checkout order.
-			$nets_easy_order = Nets_Easy()->api->get_nets_easy_order( $wc_order->get_meta( '_dibs_payment_id' ) );
+			$nets_easy_order = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 			if ( is_wp_error( $nets_easy_order ) ) {
 				$this->fetching_order_failed( $wc_order, true, $nets_easy_order->get_error_message() );
 				return;
@@ -115,7 +122,13 @@ class Nets_Easy_Order_Management {
 				return;
 			}
 
-			$nets_easy_order = Nets_Easy()->api->get_nets_easy_order( $wc_order->get_meta( '_dibs_payment_id' ) );
+			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
+			if ( empty( $payment_id ) ) {
+				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request.' );
+				return;
+			}
+
+			$nets_easy_order = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 			if ( is_wp_error( $nets_easy_order ) ) {
 				$this->fetching_order_failed( $wc_order, true, $nets_easy_order->get_error_message() );
 				return;

--- a/classes/class-nets-easy-order-management.php
+++ b/classes/class-nets-easy-order-management.php
@@ -74,7 +74,7 @@ class Nets_Easy_Order_Management {
 
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found in the order completed request for WooCommerce order ID: ' . $order_id );
+				Nets_Easy_Logger::log( 'No payment ID found in the order completed request for WooCommerce order number: ' . $wc_order->get_order_number() );
 				return;
 			}
 
@@ -124,7 +124,7 @@ class Nets_Easy_Order_Management {
 
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request for WooCommerce order ID: ' . $order_id );
+				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request for WooCommerce order number: ' . $wc_order->get_order_number() );
 				return;
 			}
 

--- a/classes/class-nets-easy-order-management.php
+++ b/classes/class-nets-easy-order-management.php
@@ -74,7 +74,7 @@ class Nets_Easy_Order_Management {
 
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found in the order completed request.' );
+				Nets_Easy_Logger::log( 'No payment ID found in the order completed request for WooCommerce order ID: ' . $order_id );
 				return;
 			}
 
@@ -124,7 +124,7 @@ class Nets_Easy_Order_Management {
 
 			$payment_id = $wc_order->get_meta( '_dibs_payment_id' );
 			if ( empty( $payment_id ) ) {
-				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request.' );
+				Nets_Easy_Logger::log( 'No payment ID found in the order canceled request for WooCommerce order ID: ' . $order_id );
 				return;
 			}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -206,7 +206,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 	}
 
 	if ( empty( $payment_id ) ) {
-		Nets_Easy_Logger::log( 'No payment ID found in the confirmation request for WooCommerce order ID: ' . $order_id );
+		Nets_Easy_Logger::log( 'No payment ID found in the confirmation request for WooCommerce order number: ' . $order->get_order_number() );
 		return;
 	}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -204,6 +204,12 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 	if ( null === $payment_id ) {
 		$payment_id = WC()->session->get( 'dibs_payment_id' );
 	}
+
+	if ( empty( $payment_id ) ) {
+		Nets_Easy_Logger::log( 'No payment ID found in the confirmation request.' );
+		return;
+	}
+
 	if ( '' !== $order->get_shipping_method() ) {
 		wc_dibs_save_shipping_reference_to_order( $order_id );
 	}

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -206,7 +206,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 	}
 
 	if ( empty( $payment_id ) ) {
-		Nets_Easy_Logger::log( 'No payment ID found in the confirmation request.' );
+		Nets_Easy_Logger::log( 'No payment ID found in the confirmation request for WooCommerce order ID: ' . $order_id );
 		return;
 	}
 


### PR DESCRIPTION
Add check if payment_id is empty, before every get_nets_easy_order request. If true, create log and return.