### PR TITLE
Fixes overlay modal not closing on "Go back"

### DIFF
--- a/assets/js/nets-easy-overlay.js
+++ b/assets/js/nets-easy-overlay.js
@@ -3,6 +3,18 @@ jQuery(function ($) {
     var netsEasyForWooCommerce = {
         init: function () {
             window.addEventListener("hashchange", netsEasyForWooCommerce.handleHashChange)
+            window.addEventListener('message', function (evt) {
+                if (evt.origin !== this.window.location.origin) {
+                    return
+                }
+
+                const events = ['nexi-close-overlay']
+                if (!events.includes(evt.data.event)) {
+                    return
+                }
+
+                netsEasyForWooCommerce.closeOverlay()
+            })
         },
 
         handleHashChange: function () {
@@ -19,13 +31,15 @@ jQuery(function ($) {
                 `<div class="netseasy-modal" id="netseasy-modal"><div class="netseasy-modal-box" id="netseasy-modal-box"><span class="close-netseasy-modal">&times;</span><iframe class="netseasy-iframe" id="netseasy-iframe" src="${url}"></iframe></div></div>`,
             )
 
-            $(".close-netseasy-modal").on("click", function () {
-                $(".netseasy-modal").hide()
-                $("form.checkout").removeClass("processing").unblock()
-                $(".woocommerce-checkout-review-order-table").unblock()
-                $("form.checkout").unblock()
-            })
+            $(".close-netseasy-modal").on("click", netsEasyForWooCommerce.closeOverlay)
         },
+
+        closeOverlay: function () {
+            $(".netseasy-modal").hide()
+            $("form.checkout").removeClass("processing").unblock()
+            $(".woocommerce-checkout-review-order-table").unblock()
+            $("form.checkout").unblock()
+        }
     }
 
     netsEasyForWooCommerce.init()

--- a/assets/js/nets-easy-overlay.js
+++ b/assets/js/nets-easy-overlay.js
@@ -3,18 +3,7 @@ jQuery(function ($) {
     var netsEasyForWooCommerce = {
         init: function () {
             window.addEventListener("hashchange", netsEasyForWooCommerce.handleHashChange)
-            window.addEventListener('message', function (evt) {
-                if (evt.origin !== this.window.location.origin) {
-                    return
-                }
-
-                const events = ['nexi-close-overlay']
-                if (!events.includes(evt.data.event)) {
-                    return
-                }
-
-                netsEasyForWooCommerce.closeOverlay()
-            })
+            window.addEventListener("message", netsEasyForWooCommerce.handleMessage)
         },
 
         handleHashChange: function () {
@@ -24,6 +13,20 @@ jQuery(function ($) {
                 var url = atob(splittedHash[1])
                 netsEasyForWooCommerce.addIframe(url)
             }
+        },
+
+        // Handle messages from the iframe.
+        handleMessage: function (evt) {
+            if (evt.origin !== this.window.location.origin) {
+                return
+            }
+
+            const events = ["nexi-close-overlay"]
+            if (!events.includes(evt.data.event)) {
+                return
+            }
+
+            netsEasyForWooCommerce.closeOverlay()
         },
 
         addIframe: function (url) {
@@ -39,7 +42,7 @@ jQuery(function ($) {
             $("form.checkout").removeClass("processing").unblock()
             $(".woocommerce-checkout-review-order-table").unblock()
             $("form.checkout").unblock()
-        }
+        },
     }
 
     netsEasyForWooCommerce.init()

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -63,27 +63,7 @@ class Nets_Easy_Assets {
 		if ( 'overlay' === $this->checkout_flow ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'load_overlay_js' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_overlay_css' ) );
-			add_action(
-				'wp_print_scripts',
-				function () {
-					if ( ! isset( $_GET['nets_overlay'] ) ) {
-						return;
-					}
-					$nonce = wp_create_nonce( 'nexi-close-overlay' )
-					?>
-				<script>
-					message = {
-						event: 'nexi-close-overlay',
-						nonce: "<?php echo $nonce; ?>"
-					}
-					console.log('child: ', message)
-					window.parent.postMessage(message, {
-						targetOrigin: "<?php echo esc_url( ( home_url() ) ); ?>"
-					})
-				</script>
-					<?php
-				}
-			);
+			add_action( 'wp_print_scripts', array( $this, 'inject_iframe_script' ) );
 		}
 	}
 
@@ -108,6 +88,25 @@ class Nets_Easy_Assets {
 			return 'https://test.checkout.dibspayment.eu/v1/checkout.js?v=1';
 		}
 		return 'https://checkout.dibspayment.eu/v1/checkout.js?v=1';
+	}
+
+	/**
+	 * Injects the iframe script.
+	 */
+	public function inject_iframe_script() {
+		if ( ! isset( $_GET['nexi_overlay'] ) ) {
+			return;
+		}
+		?>
+		<script>
+			message = {
+				event: 'nexi-close-overlay',
+			}
+			window.parent.postMessage(message, {
+				targetOrigin: "<?php echo esc_url( ( home_url() ) ); ?>"
+			})
+		</script>
+		<?php
 	}
 
 	/**

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -63,8 +63,28 @@ class Nets_Easy_Assets {
 		if ( 'overlay' === $this->checkout_flow ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'load_overlay_js' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'dibs_overlay_css' ) );
+			add_action(
+				'wp_print_scripts',
+				function () {
+					if ( ! isset( $_GET['nets_overlay'] ) ) {
+						return;
+					}
+					$nonce = wp_create_nonce( 'nexi-close-overlay' )
+					?>
+				<script>
+					message = {
+						event: 'nexi-close-overlay',
+						nonce: "<?php echo $nonce; ?>"
+					}
+					console.log('child: ', message)
+					window.parent.postMessage(message, {
+						targetOrigin: "<?php echo esc_url( ( home_url() ) ); ?>"
+					})
+				</script>
+					<?php
+				}
+			);
 		}
-
 	}
 
 	/**

--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -55,6 +55,7 @@ class Nets_Easy_Checkout_Helper {
 
 			if ( 'overlay' === $checkout_flow ) {
 				$return_url = add_query_arg( array( 'nets_reload' => 'true' ), $return_url );
+				$cancel_url = add_query_arg( array( 'nets_overlay' => 'true' ), home_url() );
 			}
 
 			$checkout['returnUrl']                               = esc_url_raw( $return_url );

--- a/classes/requests/helpers/class-nets-easy-checkout-helper.php
+++ b/classes/requests/helpers/class-nets-easy-checkout-helper.php
@@ -55,7 +55,7 @@ class Nets_Easy_Checkout_Helper {
 
 			if ( 'overlay' === $checkout_flow ) {
 				$return_url = add_query_arg( array( 'nets_reload' => 'true' ), $return_url );
-				$cancel_url = add_query_arg( array( 'nets_overlay' => 'true' ), home_url() );
+				$cancel_url = add_query_arg( array( 'nexi_overlay' => 'true' ), home_url() );
 			}
 
 			$checkout['returnUrl']                               = esc_url_raw( $return_url );


### PR DESCRIPTION
Currently, when the customer clicks on the "Go back" button inside the Nexi iframe, they'll be redirected to `cancelUrl` instead of closing the overlay.

**New behavior when clicking on "Go back":**
- redirect the customer (inside the iframe) to any page (in this case, `home_url`) with the `nexi_overlay` query parameter set.
- if the `nexi_overlay` parameter is set, inject a script that instructs the iframe to send a `postMessage` to the parent window (i.e., our custom overlay).
- the parent window listens for a `nexi-close-overlay` event. If it exists, the overlay is closed.

https://app.clickup.com/t/8696dewmy