### PR TITLE
Change payment method not working fix

### DIFF
--- a/classes/class-nets-easy-ajax.php
+++ b/classes/class-nets-easy-ajax.php
@@ -254,7 +254,7 @@ class Nets_Easy_Ajax extends WC_AJAX {
 
 		$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 		$dibs_easy          = filter_input( INPUT_POST, 'dibs_easy', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		if ( wc_string_to_bool( $dibs_easy ) ) {
+		if ( 'false' === $dibs_easy ) {
 			// Set chosen payment method to first gateway that is not DIBS Easy.
 			$first_gateway = reset( $available_gateways );
 			if ( 'dibs_easy' !== $first_gateway->id ) {

--- a/classes/class-nets-easy-templates.php
+++ b/classes/class-nets-easy-templates.php
@@ -128,43 +128,14 @@ class Nets_Easy_Templates {
 	 * @return string
 	 */
 	public function maybe_replace_checkout( $template, $template_name ) {
-
 		if ( 'checkout/form-checkout.php' === $template_name ) {
 
-			$maybe_template     = locate_template( 'woocommerce/nets-easy-checkout.php' );
-			$nexi_template      = $maybe_template ? $maybe_template : WC_DIBS_PATH . '/templates/nets-easy-checkout.php';
-			$confirm            = filter_input( INPUT_GET, 'confirm', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-			$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
-			if ( array_key_exists( 'dibs_easy', $available_gateways ) ) {
-				// If chosen payment method exists.
-				if ( 'dibs_easy' === WC()->session->get( 'chosen_payment_method' ) ) {
-					error_log( '1' );
-					return $nexi_template;
-				}
+			$maybe_template = locate_template( 'woocommerce/nets-easy-checkout.php' );
+			$nexi_template  = $maybe_template ? $maybe_template : WC_DIBS_PATH . '/templates/nets-easy-checkout.php';
 
-				// If chosen payment method does not exist and Nexi is the first gateway.
-				if ( null === WC()->session->get( 'chosen_payment_method' ) || '' === WC()->session->get( 'chosen_payment_method' ) ) {
-					reset( $available_gateways );
-
-					if ( 'dibs_easy' === key( $available_gateways ) ) {
-						error_log( '2' );
-						return $nexi_template;
-					}
-				}
-
-				// If another gateway is saved in session, but has since become unavailable.
-				if ( WC()->session->get( 'chosen_payment_method' ) ) {
-					if ( ! array_key_exists( WC()->session->get( 'chosen_payment_method' ), $available_gateways ) ) {
-						reset( $available_gateways );
-
-						if ( 'dibs_easy' === key( $available_gateways ) ) {
-							error_log( '3' );
-							return $nexi_template;
-						}
-					}
-				}
-			}
+			return $nexi_template;
 		}
+
 		return $template;
 	}
 


### PR DESCRIPTION
Reverted this check to what was used in version 2.10.4 of the plugin, as `wc_string_to_bool` needs a 'yes'/'no' value but 'true'/'false' is returned here.

If a string to bool conversion really needed here, we could of course solve this in some other way, let me know if this should be done.