### PR TITLE
Fixes the inline checkout not updating

### DIFF
--- a/assets/js/nexi-checkout-inline.js
+++ b/assets/js/nexi-checkout-inline.js
@@ -32,7 +32,7 @@ jQuery( function ( $ ) {
                     const changedGateway = $( 'input[name="payment_method"]:checked' ).val()
 
                     // If neither the changed nor the previously selected gateway is Nexi Checkout, return.
-                    if( changedGateway !== "dibs_easy" && wcNexiCheckout.selectedGateway !== "dibs_easy" ) {
+                    if ( changedGateway !== "dibs_easy" && wcNexiCheckout.selectedGateway !== "dibs_easy" ) {
                         return
                     }
 
@@ -49,6 +49,10 @@ jQuery( function ( $ ) {
                 } )
 
                 wcNexiCheckout.loadNexi()
+
+                // Update the Nexi Checkout when the checkout is updated.
+                wcNexiCheckout.bodyEl.on( "update_checkout", wcNexiCheckout.updateCheckout )
+                wcNexiCheckout.bodyEl.on( "updated_checkout", wcNexiCheckout.updatedCheckout )
             } )
 
             $( "#nexi-inline-close-modal" ).on( "click", () => {
@@ -61,6 +65,21 @@ jQuery( function ( $ ) {
                 wcNexiCheckout.blockUI()
                 wcNexiCheckout.changeSelectedGateway( false )
             } )
+        },
+
+        updateCheckout() {
+            wcNexiCheckout.log( "update_checkout" )
+            if ( window.Dibs !== undefined ) {
+                wcNexiCheckout.blockUI()
+                wcNexiCheckout.nexiCheckout.freezeCheckout()
+            }
+        },
+        updatedCheckout() {
+            wcNexiCheckout.log( "updated_checkout" )
+            if ( window.Dibs !== undefined ) {
+                wcNexiCheckout.nexiCheckout.thawCheckout()
+                wcNexiCheckout.unblockUI()
+            }
         },
 
         /**

--- a/classes/class-nets-easy-checkout.php
+++ b/classes/class-nets-easy-checkout.php
@@ -27,7 +27,7 @@ class Nets_Easy_Checkout {
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_nets_easy_order' ), 999999 );
 		add_filter( 'allowed_redirect_hosts', array( $this, 'extend_allowed_domains_list' ) );
 
-		if ( 'embedded' === $this->checkout_flow ) {
+		if ( in_array( $this->checkout_flow, array( 'embedded', 'inline' ), true ) ) {
 			add_filter( 'woocommerce_checkout_fields', array( $this, 'add_hidden_payment_id_field' ), 30 );
 		}
 	}

--- a/classes/class-nets-easy-templates.php
+++ b/classes/class-nets-easy-templates.php
@@ -47,6 +47,9 @@ class Nets_Easy_Templates {
 		add_action( 'wc_dibs_after_order_review', 'wc_dibs_show_another_gateway_button', 20 );
 		add_action( 'wc_dibs_after_snippet', array( $this, 'add_wc_form' ), 10 );
 
+		// Required for the update_order_review to work.
+		add_action( 'nexi_inline_before_snippet', array( $this, 'add_hidden_payment_method_field' ) );
+
 		// Since Nexi Inline overrides the payment method template, we need to add a "Select another payment method" button.
 		add_action( 'nexi_inline_after_snippet', 'wc_dibs_show_another_gateway_button' );
 	}
@@ -173,6 +176,21 @@ class Nets_Easy_Templates {
 			</div>
 			<input id="payment_method_dibs_easy" type="radio" class="input-radio" name="payment_method" value="dibs_easy" checked="checked" />
 		</div>
+		<?php
+	}
+
+	/**
+	 * Adds the payment method field to the checkout page.
+	 *
+	 * The update_order_review requires that the payment method field is either a checkbox or a radio button to be included in the $_POST data which is used for setting the chosen_payment_method, otherwise it will return an empty string.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/blob/7d2d3b87a32f4d83a673a62af863af89c9a6d7e5/plugins/woocommerce/client/legacy/js/frontend/checkout.js#L481-L497
+	 *
+	 * @return void
+	 */
+	public function add_hidden_payment_method_field() {
+		?>
+		<input id="payment_method_dibs_easy" type="radio" class="input-radio" name="payment_method" value="dibs_easy" checked="checked" hidden="true" />
 		<?php
 	}
 


### PR DESCRIPTION
The Nexi form is not being updated when the inline flow is selected.

- adds a hidden payment method field to ensure WC set the `chosen_payment_method`.
- adds `update_checkout` and `updated_checkout` event listeners to determine when to lock/unlock the Nexi form.
- the WC fields will now be blocked when Nexi is locked.

https://app.clickup.com/t/8699m6n23