### PR TITLE
Default to dibs_payment_id if payment id is null or empty

### DIFF
--- a/assets/js/nets-easy-for-woocommerce.js
+++ b/assets/js/nets-easy-for-woocommerce.js
@@ -213,7 +213,11 @@ jQuery( function ( $ ) {
          * Init Dibs Easy Checkout
          */
         initDibsCheckout() {
-            let paymentId = $( "#nexi_payment_id" ).val() ?? wcDibsEasy.dibs_payment_id
+            let paymentId = $( "#nexi_payment_id" ).val()
+            if ( ! paymentId ) {
+                paymentId = wcDibsEasy.dibs_payment_id
+            }
+
             // Constructs a new Checkout object.
             dibsEasyForWoocommerce.dibsCheckout = new Dibs.Checkout( {
                 checkoutKey: wcDibsEasy.privateKey,


### PR DESCRIPTION
The existing check doesn't take empty value into consideration, as we've had instances where the field exists in the HTML, but the value is empty.

- checks if payment ID retrieved from the HTML is empty, and defaults to the one passed through the JS params if it is.

https://app.clickup.com/t/8699x3k5n