### PR TITLE
Display correct Nexi Checkout Card payment logo

### DIFF
--- a/.changelogs/2026-03-11-use-new-logo-gateway
+++ b/.changelogs/2026-03-11-use-new-logo-gateway
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+The Nexi logo is now correctly displayed on the Nexi Checkout Card payment settings page.

--- a/src/PaymentMethods/BaseGateway.php
+++ b/src/PaymentMethods/BaseGateway.php
@@ -453,7 +453,7 @@ abstract class BaseGateway extends WC_Payment_Gateway {
 			return $this->payment_gateway_icon;
 		}
 
-		return WC_DIBS__URL . '/assets/images/nexi-logo.svg';
+		return WC_DIBS__URL . '/assets/images/nexi-logo.png';
 	}
 
 	/**


### PR DESCRIPTION
The Nexi logo is now correctly displayed on the Nexi Checkout Card payment settings page.