### PR TITLE
Add compatibility with synchronized subscriptions

### DIFF
--- a/.changelogs/2026-04-02-synchronized-subscription
+++ b/.changelogs/2026-04-02-synchronized-subscription
@@ -1,4 +1,4 @@
-Type: Feature
+Type: Fix
 Needs Documentation: no
 
 Added support for synchronized subscription.

--- a/.changelogs/2026-04-02-synchronized-subscription
+++ b/.changelogs/2026-04-02-synchronized-subscription
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-Added support for synchronized subscription.
+Fixed an issue where shipping costs were incorrectly included during the grace period for synchronized subscriptions. This caused mismatches between WooCommerce and Nexi Checkout, which would fail the payment.

--- a/.changelogs/2026-04-02-synchronized-subscription
+++ b/.changelogs/2026-04-02-synchronized-subscription
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: no
+
+Added support for synchronized subscription.

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -177,7 +177,6 @@ class Nets_Easy_Cart_Helper {
 	 * Gets the sku for one item.
 	 *
 	 * @param object $product The WooCommerce product.
-	 * @param string $product_id The WooCommerce product ID.
 	 * @return string
 	 */
 	public static function get_sku( $product ) {

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -135,7 +135,6 @@ class Nets_Easy_Cart_Helper {
 	 * @return array|null
 	 */
 	public static function get_shipping() {
-		WC()->cart->calculate_shipping();
 		$packages        = WC()->shipping->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -144,7 +144,7 @@ class Nets_Easy_Cart_Helper {
 				if ( $chosen_shipping === $method->id ) {
 					if ( $method->cost > 0 ) {
 						return array(
-							'reference'        => 'shipping|' . $method->id,
+							'reference'        => "shipping|{$method->id}",
 							'name'             => wc_dibs_clean_name( $method->label ),
 							'quantity'         => 1,
 							'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),
@@ -157,7 +157,7 @@ class Nets_Easy_Cart_Helper {
 					}
 
 					return array(
-						'reference'        => 'shipping|' . $method->id,
+						'reference'        => "shipping|{$method->id}",
 						'name'             => wc_dibs_clean_name( $method->label ),
 						'quantity'         => 1,
 						'unit'             => __( 'pcs', 'dibs-easy-for-woocommerce' ),

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -136,8 +136,8 @@ class Nets_Easy_Cart_Helper {
 	 */
 	public static function get_shipping() {
 		$packages        = WC()->shipping->get_packages();
-		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
-		$chosen_shipping = $chosen_methods[0];
+		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods', array() );
+		$chosen_shipping = $chosen_methods[0] ?? array();
 		foreach ( $packages as $i => $package ) {
 			foreach ( $package['rates'] as $method ) {
 				if ( $chosen_shipping === $method->id ) {

--- a/classes/requests/helpers/class-nets-easy-cart-helper.php
+++ b/classes/requests/helpers/class-nets-easy-cart-helper.php
@@ -180,7 +180,7 @@ class Nets_Easy_Cart_Helper {
 	 * @param string $product_id The WooCommerce product ID.
 	 * @return string
 	 */
-	public static function get_sku( $product, $product_id ) {
+	public static function get_sku( $product ) {
 		$part_number = $product->get_sku();
 		if ( empty( $part_number ) ) {
 			$part_number = $product->get_id();


### PR DESCRIPTION
The `WC()->cart->calculate_shipping()` call that is now removed was causing the shipping packages to re-evaluated which resulted in the WC subscription changes being overwritten. For some reason, in this re-evaluation, WC subscription doesn't run their filter again.

https://app.clickup.com/t/869cevnpj