### PR TITLE
Redirect if payment is already completed while still on checkout

### DIFF
--- a/.changelogs/2026-04-12-avoid-looping-shipping-packages
+++ b/.changelogs/2026-04-12-avoid-looping-shipping-packages
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+Skipped iterating through shipping packages when no shipping method is chosen.

--- a/.changelogs/2026-04-12-payment-id-change
+++ b/.changelogs/2026-04-12-payment-id-change
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+Due to API changes, the paymentId query parameter has been changed to paymentid.

--- a/.changelogs/2026-04-12-payment-id-change
+++ b/.changelogs/2026-04-12-payment-id-change
@@ -1,4 +1,4 @@
 Type: Tweak
 Needs Documentation: no
 
-Due to API changes, the paymentId query parameter has been changed to paymentid.
+Due to API changes, the paymentid query parameter is now used. paymentId is still supported for compatibility.

--- a/.changelogs/2026-04-12-undefined-shipping-method
+++ b/.changelogs/2026-04-12-undefined-shipping-method
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed undefined shipping method when shipping is checked after opurchase is completed.

--- a/.changelogs/2026-04-12-undefined-shipping-method
+++ b/.changelogs/2026-04-12-undefined-shipping-method
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-Fixed undefined shipping method when shipping is checked after opurchase is completed.
+Fixed undefined shipping method when checking for shipping at purchase completion.

--- a/.changelogs/2026-04-12-url-encoding
+++ b/.changelogs/2026-04-12-url-encoding
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed special query characters being incorrectly encoded.

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -107,12 +107,15 @@ class Nets_Easy_Confirmation {
 	 */
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
 		// At some point we used paymentId, but now it seems to be paymentid.
-		$payment_id = $_GET['paymentId'] ?? $_GET['paymentid'] ?? ''; // phpcs:ignore
+		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		if ( empty( $payment_id ) ) {
+			$payment_id = filter_input( INPUT_GET, 'paymentid', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		}
+
 		if ( empty( $payment_id ) ) {
 			return;
 		}
 
-		$payment_id = sanitize_text_field( wp_unslash( $payment_id ) );
 		Nets_Easy_Logger::log( "$payment_id Customer redirected back to checkout. Checking payment status." );
 
 		$request = Nets_Easy()->api->get_nets_easy_order( $payment_id );

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -107,7 +107,7 @@ class Nets_Easy_Confirmation {
 	 */
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
 		// At some point it we used paymentId, but now it seems to be paymentid.
-		$payment_id = $_GET['paymentId'] ?? $_GET['paymentid'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$payment_id = $_GET['paymentId'] ?? $_GET['paymentid'] ?? ''; // phpcs:ignore
 		if ( empty( $payment_id ) ) {
 			return;
 		}

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -129,23 +129,23 @@ class Nets_Easy_Confirmation {
 				return;
 			}
 
-			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment created. Order ID ' . $order->get_id() );
+			Nets_Easy_Logger::log( "$payment_id Customer redirected back to checkout. Payment created. Order ID {$order->get_id()}" );
 
 			if ( empty( $order->get_date_paid() ) ) {
 
-				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order->get_id() . '. Confirming the order.' );
+				Nets_Easy_Logger::log( "$payment_id Order ID {$order->get_id()}. Confirming the order." );
 				// Confirm the order.
 				wc_dibs_confirm_dibs_order( $order->get_id() );
 				wc_dibs_unset_sessions();
-				wp_safe_redirect( html_entity_decode( $order->get_checkout_order_received_url(), ENT_QUOTES ) );
-				exit;
 
 			} else {
-				Nets_Easy_Logger::log( $payment_id . '. Order ID ' . $order->get_id() . '. Order already confirmed.' );
-				return;
+				Nets_Easy_Logger::log( "$payment_id Order ID {$order->get_id()}. Order already confirmed. Redirecting to thank you page." );
 			}
+
+			wp_safe_redirect( html_entity_decode( $order->get_checkout_order_received_url(), ENT_QUOTES ) );
+			exit;
 		} else {
-			Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Payment status is NOT paid.' );
+			Nets_Easy_Logger::log( "$payment_id Customer redirected back to checkout. Payment status is NOT paid." );
 		}
 	}
 }

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -57,10 +57,10 @@ class Nets_Easy_Confirmation {
 		$reload = filter_input( INPUT_GET, 'nets_reload', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $reload ) ) {
-			$url = esc_url_raw( home_url( remove_query_arg( 'nets_reload' ) ) );
+			$url = sanitize_url( home_url( remove_query_arg( 'nets_reload' ) ) );
 			?>
 			<script>
-				top.location = <?php echo wp_json_encode( $url ); ?>;
+				top.location = <?php echo esc_url_raw( $url ); ?>;
 			</script>
 			<?php
 			wp_die();

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -60,7 +60,7 @@ class Nets_Easy_Confirmation {
 			$url = sanitize_url( home_url( remove_query_arg( 'nets_reload' ) ) );
 			?>
 			<script>
-				top.location = <?php echo esc_url_raw( $url ); ?>;
+				top.location = "<?php echo esc_url_raw( $url ); ?>"
 			</script>
 			<?php
 			wp_die();

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -57,10 +57,10 @@ class Nets_Easy_Confirmation {
 		$reload = filter_input( INPUT_GET, 'nets_reload', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $reload ) ) {
-			$url = remove_query_arg( 'nets_reload' );
+			$url = esc_url_raw( home_url( remove_query_arg( 'nets_reload' ) ) );
 			?>
 			<script>
-				top.location = "<?php echo esc_url_raw( $url ); ?>"
+				top.location = <?php echo wp_json_encode( $url ); ?>;
 			</script>
 			<?php
 			wp_die();

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -60,7 +60,7 @@ class Nets_Easy_Confirmation {
 			$url = remove_query_arg( 'nets_reload' );
 			?>
 			<script>
-				top.location = "<?php echo esc_url( $url ); ?>"
+				top.location = "<?php echo esc_url_raw( $url ); ?>"
 			</script>
 			<?php
 			wp_die();

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -106,7 +106,7 @@ class Nets_Easy_Confirmation {
 	 * It needs to be triggered after similar logic in the subscription class (dibs_payment_method_changed).
 	 */
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
-		// At some point it we used paymentId, but now it seems to be paymentid.
+		// At some point we used paymentId, but now it seems to be paymentid.
 		$payment_id = $_GET['paymentId'] ?? $_GET['paymentid'] ?? ''; // phpcs:ignore
 		if ( empty( $payment_id ) ) {
 			return;

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -106,13 +106,14 @@ class Nets_Easy_Confirmation {
 	 * It needs to be triggered after similar logic in the subscription class (dibs_payment_method_changed).
 	 */
 	public function maybe_confirm_customer_redirected_from_payment_page_order() {
-
-		$payment_id = filter_input( INPUT_GET, 'paymentId', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		// At some point it we used paymentId, but now it seems to be paymentid.
+		$payment_id = $_GET['paymentId'] ?? $_GET['paymentid'] ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( empty( $payment_id ) ) {
 			return;
 		}
 
-		Nets_Easy_Logger::log( $payment_id . '. Customer redirected back to checkout. Checking payment status.' );
+		$payment_id = sanitize_text_field( wp_unslash( $payment_id ) );
+		Nets_Easy_Logger::log( "$payment_id Customer redirected back to checkout. Checking payment status." );
 
 		$request = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -285,10 +285,11 @@ function wc_dibs_save_shipping_reference_to_order( $order_id ) {
 		$packages        = WC()->shipping->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];
+		$chosen_shipping = $chosen_methods[0] ?? '';
 		foreach ( $packages as $i => $package ) {
 			foreach ( $package['rates'] as $method ) {
 				if ( $chosen_shipping === $method->id ) {
-					$order->update_meta_data( '_nets_shipping_reference', 'shipping|' . $method->id );
+					$order->update_meta_data( '_nets_shipping_reference', "shipping|{$method->id}" );
 					$order->save();
 				}
 			}

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -366,14 +366,15 @@ function dibs_easy_print_error_message( $wp_error ) {
 /**
  * Finds an order based on a payment ID (the Nets order number).
  *
- * @param string $payment_id Nets order number saved as Payment ID in WC order.
+ * @param string      $payment_id Nets order number saved as Payment ID in WC order.
+ * @param string|null $date_after Optional date to limit the search to orders created after a certain date. Format: 'YYYY-MM-DD HH:MM:SS'.
  * @return object|bool The WooCommerce order, or false if the order could not be found.
  */
 function nets_easy_get_order_by_purchase_id( $payment_id, $date_after = null ) {
 
 	$args = array(
-		'meta_key'     => '_dibs_payment_id',
-		'meta_value'   => wc_clean( wp_unslash( $payment_id ) ),
+		'meta_key'     => '_dibs_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'meta_value'   => wc_clean( wp_unslash( $payment_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		'meta_compare' => '=',
 		'order'        => 'DESC',
 		'orderby'      => 'date',

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -282,13 +282,13 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 function wc_dibs_save_shipping_reference_to_order( $order_id ) {
 	$order = wc_get_order( $order_id );
 	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
-		$packages        = WC()->shipping->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen_shipping = $chosen_methods[0] ?? '';
 		if ( empty( $chosen_shipping ) ) {
 			return;
 		}
 
+		$packages = WC()->shipping->get_packages();
 		foreach ( $packages as $i => $package ) {
 			foreach ( $package['rates'] as $method ) {
 				if ( $chosen_shipping === $method->id ) {

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -371,10 +371,11 @@ function dibs_easy_print_error_message( $wp_error ) {
  * @return object|bool The WooCommerce order, or false if the order could not be found.
  */
 function nets_easy_get_order_by_purchase_id( $payment_id, $date_after = null ) {
-
-	$args = array(
-		'meta_key'     => '_dibs_payment_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		'meta_value'   => wc_clean( wp_unslash( $payment_id ) ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$meta_key   = '_dibs_payment_id';
+	$meta_value = wc_clean( wp_unslash( $payment_id ) );
+	$args       = array(
+		'meta_key'     => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'meta_value'   => $meta_value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		'meta_compare' => '=',
 		'order'        => 'DESC',
 		'orderby'      => 'date',
@@ -396,10 +397,10 @@ function nets_easy_get_order_by_purchase_id( $payment_id, $date_after = null ) {
 	$order = reset( $orders );
 
 	// Validate that the order actual has the metadata we're looking for, and that it is the same.
-	$meta_value = $order->get_meta( '_dibs_payment_id', true );
+	$stored_payment_id = $order->get_meta( '_dibs_payment_id', true );
 
 	// If the meta value is not the same as the Nexi payment id, return false.
-	if ( $meta_value !== $payment_id ) {
+	if ( $meta_value !== $stored_payment_id ) {
 		return false;
 	}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -283,7 +283,7 @@ function wc_dibs_save_shipping_reference_to_order( $order_id ) {
 	$order = wc_get_order( $order_id );
 	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
 		$packages        = WC()->shipping->get_packages();
-		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
+		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods', array() );
 		$chosen_shipping = $chosen_methods[0] ?? '';
 		if ( empty( $chosen_shipping ) ) {
 			return;

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -284,8 +284,11 @@ function wc_dibs_save_shipping_reference_to_order( $order_id ) {
 	if ( isset( WC()->session ) && method_exists( WC()->session, 'get' ) ) {
 		$packages        = WC()->shipping->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
-		$chosen_shipping = $chosen_methods[0];
 		$chosen_shipping = $chosen_methods[0] ?? '';
+		if ( empty( $chosen_shipping ) ) {
+			return;
+		}
+
 		foreach ( $packages as $i => $package ) {
 			foreach ( $package['rates'] as $method ) {
 				if ( $chosen_shipping === $method->id ) {


### PR DESCRIPTION
Nexi already perform their own controls. After forcing the checkout to be reloaded, Nexi correctly detected the purchase was completed, and correctly attempted to redirect to the return URL. However, for the overlay flow, there wasn't any checks. This is what this PR addresses along with other issues detected during development (see changelogs).

https://app.clickup.com/t/869ctufx1