### PR TITLE
Split payment methods pay for order support

### DIFF
--- a/.changelogs/2026-04-23-split-pay-for-order
+++ b/.changelogs/2026-04-23-split-pay-for-order
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-For "Pay for order" orders that uses a split Nexi payment method, only that selected payment method is now available on the customer payment page.
+For "Pay for order" orders that use a split Nexi payment method, only that selected payment method is now available on the customer payment page.

--- a/.changelogs/2026-04-23-split-pay-for-order
+++ b/.changelogs/2026-04-23-split-pay-for-order
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+For "Pay for order" orders that uses a split Nexi payment method, only that selected payment method is now available on the customer payment page.

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -437,7 +437,7 @@ function nexi_filter_order_pay_gateways( $available_gateways ) {
 	}
 
 	$order = wc_get_order( $order_id );
-	if ( ! $order ) {
+	if ( ! $order || ! $order->needs_payment() ) {
 		return $available_gateways;
 	}
 
@@ -454,7 +454,7 @@ function nexi_filter_order_pay_gateways( $available_gateways ) {
 		);
 	}
 
-	return array();
+	return $available_gateways;
 }
 
 /**
@@ -482,10 +482,11 @@ function nexi_allow_split_gateway_on_order_pay( $is_available, $gateway ) {
 		return $is_available;
 	}
 
-	$original_gateway = $order->get_payment_method();
-	$split_gateways   = array_diff( nets_easy_all_payment_method_ids(), array( 'dibs_easy' ) );
+	$original_gateway   = $order->get_payment_method();
+	$split_gateways     = array_diff( nets_easy_all_payment_method_ids(), array( 'dibs_easy' ) );
+	$gateway_is_enabled = isset( $gateway->enabled ) && 'yes' === $gateway->enabled;
 
-	if ( in_array( $original_gateway, $split_gateways, true ) && $gateway->id === $original_gateway ) {
+	if ( in_array( $original_gateway, $split_gateways, true ) && $gateway->id === $original_gateway && $gateway_is_enabled ) {
 		return true;
 	}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -416,6 +416,49 @@ function nets_easy_all_payment_method_ids() {
 	return array( 'dibs_easy', 'nets_easy_card', 'nets_easy_sofort', 'nets_easy_trustly', 'nets_easy_swish', 'nets_easy_ratepay_sepa', 'nets_easy_klarna', 'nets_easy_mobilepay', 'nets_easy_vipps' );
 }
 
+/**
+ * Only display available payment gateways on order-pay for split Nexi methods.
+ *
+ * If an order was originally created with a split Nexi gateway (e.g. Card),
+ * keep only that same gateway available during the pay-for-order flow.
+ *
+ * @param array $available_gateways Available gateways.
+ * @return array
+ */
+function nexi_filter_order_pay_gateways( $available_gateways ) {
+	if ( ! is_checkout_pay_page() || empty( $available_gateways ) ) {
+		return $available_gateways;
+	}
+
+	$order_id = absint( get_query_var( 'order-pay' ) );
+
+	if ( empty( $order_id ) ) {
+		return $available_gateways;
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return $available_gateways;
+	}
+
+	$original_gateway = $order->get_payment_method();
+	$split_gateways   = array_diff( nets_easy_all_payment_method_ids(), array( 'dibs_easy' ) );
+
+	if ( ! in_array( $original_gateway, $split_gateways, true ) ) {
+		return $available_gateways;
+	}
+
+	if ( isset( $available_gateways[ $original_gateway ] ) ) {
+		return array(
+			$original_gateway => $available_gateways[ $original_gateway ],
+		);
+	}
+
+	return array();
+}
+
+add_filter( 'woocommerce_available_payment_gateways', 'nexi_filter_order_pay_gateways', 999 );
+
 
 /**
  * Get payment method title.

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -457,7 +457,43 @@ function nexi_filter_order_pay_gateways( $available_gateways ) {
 	return array();
 }
 
+/**
+ * Allow split Nexi gateway on order-pay regardless of checkout flow.
+ *
+ * For the pay-for-order flow we need the originally selected split method to stay
+ * available even if the global flow is embedded/inline.
+ *
+ * @param bool               $is_available Current availability.
+ * @param WC_Payment_Gateway $gateway Gateway instance.
+ * @return bool
+ */
+function nexi_allow_split_gateway_on_order_pay( $is_available, $gateway ) {
+	if ( ! is_checkout_pay_page() ) {
+		return $is_available;
+	}
+
+	$order_id = absint( get_query_var( 'order-pay' ) );
+	if ( empty( $order_id ) ) {
+		return $is_available;
+	}
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order || ! $order->needs_payment() ) {
+		return $is_available;
+	}
+
+	$original_gateway = $order->get_payment_method();
+	$split_gateways   = array_diff( nets_easy_all_payment_method_ids(), array( 'dibs_easy' ) );
+
+	if ( in_array( $original_gateway, $split_gateways, true ) && $gateway->id === $original_gateway ) {
+		return true;
+	}
+
+	return $is_available;
+}
+
 add_filter( 'woocommerce_available_payment_gateways', 'nexi_filter_order_pay_gateways', 999 );
+add_filter( 'nexi_is_available', 'nexi_allow_split_gateway_on_order_pay', 10, 2 );
 
 
 /**


### PR DESCRIPTION
Makes sure that "Pay for order"-orders that uses a split Nexi payment method, only have that selected payment method available on the customer payment page.