### PR TITLE
Added 2nd paramter to http_headers_useragent

### DIFF
--- a/.changelogs/2026-05-12-missing-url-parameter-user-agent
+++ b/.changelogs/2026-05-12-missing-url-parameter-user-agent
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Added the request URL as the 2nd parameter to the 'http_headers_useragent' filter which is required for other plugins that hook onto this filter that need the URL to modify the user agent string accordingly.

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -147,11 +147,13 @@ abstract class Nets_Easy_Request {
 		$protocols  = array( 'http://', 'http://www.', 'https://', 'https://www.' );
 		$wp_version = get_bloginfo( 'version' );
 		$wp_url     = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
-		return apply_filters(
-			'dibs_easy_http_useragent',
+		$user_agent = apply_filters(
+			'http_headers_useragent',
 			"WordPress/{$wp_version}; {$wp_url} - Plugin/" . WC_DIBS_EASY_VERSION . ' - PHP/' . PHP_VERSION . ' - Krokedil',
 			$this->get_request_url()
 		);
+
+		return apply_filters( 'dibs_easy_request_user_agent', $user_agent, $this->get_request_url() );
 	}
 
 	/**

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -144,9 +144,9 @@ abstract class Nets_Easy_Request {
 	 * @return string
 	 */
 	protected function get_user_agent() {
-		$protocols  = array( 'http://', 'http://www.', 'https://', 'https://www.' );
-		$wp_version = get_bloginfo( 'version' );
-		$wp_url     = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
+		$protocols   = array( 'http://', 'http://www.', 'https://', 'https://www.' );
+		$wp_version  = get_bloginfo( 'version' );
+		$wp_url      = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
 		$request_url = $this->get_request_url();
 		$user_agent  = apply_filters(
 			'http_headers_useragent',

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -147,13 +147,14 @@ abstract class Nets_Easy_Request {
 		$protocols  = array( 'http://', 'http://www.', 'https://', 'https://www.' );
 		$wp_version = get_bloginfo( 'version' );
 		$wp_url     = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
-		$user_agent = apply_filters(
+		$request_url = $this->get_request_url();
+		$user_agent  = apply_filters(
 			'http_headers_useragent',
 			"WordPress/{$wp_version}; {$wp_url} - Plugin/" . WC_DIBS_EASY_VERSION . ' - PHP/' . PHP_VERSION . ' - Krokedil',
-			$this->get_request_url()
+			$request_url
 		);
 
-		return apply_filters( 'dibs_easy_request_user_agent', $user_agent, $this->get_request_url() );
+		return apply_filters( 'dibs_easy_request_user_agent', $user_agent, $request_url );
 	}
 
 	/**

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -144,9 +144,9 @@ abstract class Nets_Easy_Request {
 	 * @return string
 	 */
 	protected function get_user_agent() {
-		$protocols   = array( 'http://', 'http://www.', 'https://', 'https://www.' );
-		$wp_version  = get_bloginfo( 'version' );
-		$wp_url      = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
+		$protocols  = array( 'http://', 'http://www.', 'https://', 'https://www.' );
+		$wp_version = get_bloginfo( 'version' );
+		$wp_url     = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
 		return apply_filters(
 			'dibs_easy_http_useragent',
 			"WordPress/{$wp_version}; {$wp_url} - Plugin/" . WC_DIBS_EASY_VERSION . ' - PHP/' . PHP_VERSION . ' - Krokedil',

--- a/classes/requests/class-nets-easy-request.php
+++ b/classes/requests/class-nets-easy-request.php
@@ -144,9 +144,14 @@ abstract class Nets_Easy_Request {
 	 * @return string
 	 */
 	protected function get_user_agent() {
-		$protocols = array( 'http://', 'http://www.', 'https://', 'https://www.' );
-		$url       = str_replace( $protocols, '', get_bloginfo( 'url' ) );
-		return apply_filters( 'dibs_easy_http_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . iconv( 'UTF-8', 'ASCII//IGNORE', $url ) ) . ' - Plugin/' . WC_DIBS_EASY_VERSION . ' - PHP/' . PHP_VERSION . ' - Krokedil';
+		$protocols   = array( 'http://', 'http://www.', 'https://', 'https://www.' );
+		$wp_version  = get_bloginfo( 'version' );
+		$wp_url      = iconv( 'UTF-8', 'ASCII//IGNORE', str_replace( $protocols, '', get_bloginfo( 'url' ) ) );
+		return apply_filters(
+			'dibs_easy_http_useragent',
+			"WordPress/{$wp_version}; {$wp_url} - Plugin/" . WC_DIBS_EASY_VERSION . ' - PHP/' . PHP_VERSION . ' - Krokedil',
+			$this->get_request_url()
+		);
 	}
 
 	/**


### PR DESCRIPTION
The [`http_headers_useragent` filter](https://developer.wordpress.org/reference/hooks/http_headers_useragent/) hook which we apply expect a `$url` as a 2nd parameter which we're not passing. This has resulted in plugin that hook onto this filter unexpectedly processing a `null` value which would break functionality due to this assumption.

https://app.clickup.com/t/869d155xw