### PR TITLE
Delay redirecting until wp hook time

### DIFF
--- a/.changelogs/2026-05-13-delay-redirect-to-wp-hook
+++ b/.changelogs/2026-05-13-delay-redirect-to-wp-hook
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where some third-party plugins did not work correctly due to a redirect happening too early in the page load process.

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -41,8 +41,8 @@ class Nets_Easy_Confirmation {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'maybe_reload_page' ), 1 );
-		add_action( 'init', array( $this, 'confirm_order' ), 999 );
-		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
+		add_action( 'wp', array( $this, 'confirm_order' ), 999 );
+		add_action( 'wp', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
 	}
 
 	/**

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -42,7 +42,8 @@ class Nets_Easy_Confirmation {
 	public function __construct() {
 		add_action( 'init', array( $this, 'maybe_reload_page' ), 1 );
 		add_action( 'init', array( $this, 'confirm_order' ), 999 );
-		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
+		// Priority 999 to ensure this runs after plugins that register their `woocommerce_email_order_meta_fields` filter on `init` at priority 20 (e.g. Checkout Field Editor Pro). Otherwise the email triggered by `payment_complete()` inside this handler fires before those filters are registered, and any custom checkout fields get omitted from the email.
+		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 999 );
 	}
 
 	/**

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -41,8 +41,8 @@ class Nets_Easy_Confirmation {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'maybe_reload_page' ), 1 );
-		add_action( 'wp', array( $this, 'confirm_order' ), 999 );
-		add_action( 'wp', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
+		add_action( 'init', array( $this, 'confirm_order' ), 999 );
+		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
 	}
 
 	/**

--- a/classes/class-nets-easy-confirmation.php
+++ b/classes/class-nets-easy-confirmation.php
@@ -41,7 +41,7 @@ class Nets_Easy_Confirmation {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'maybe_reload_page' ), 1 );
-		add_action( 'init', array( $this, 'confirm_order' ), 999, 2 );
+		add_action( 'init', array( $this, 'confirm_order' ), 999 );
 		add_action( 'init', array( $this, 'maybe_confirm_customer_redirected_from_payment_page_order' ), 20 );
 	}
 

--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -259,7 +259,7 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 			// Unset sessions.
 			wc_dibs_unset_sessions();
 		} elseif ( empty( $order->get_date_paid() ) ) {
-				wc_dibs_confirm_dibs_order( $order_id );
+			wc_dibs_confirm_dibs_order( $order_id );
 		}
 	}
 

--- a/classes/class-nets-easy-gateway.php
+++ b/classes/class-nets-easy-gateway.php
@@ -259,7 +259,7 @@ class Nets_Easy_Gateway extends WC_Payment_Gateway {
 			// Unset sessions.
 			wc_dibs_unset_sessions();
 		} elseif ( empty( $order->get_date_paid() ) ) {
-			wc_dibs_confirm_dibs_order( $order_id );
+				wc_dibs_confirm_dibs_order( $order_id );
 		}
 	}
 

--- a/includes/nets-easy-functions.php
+++ b/includes/nets-easy-functions.php
@@ -202,7 +202,7 @@ function wc_dibs_confirm_dibs_order( $order_id ) {
 		wc_dibs_save_shipping_reference_to_order( $order_id );
 	}
 
-	$request = Nets_Easy()->api->get_nets_easy_order( $payment_id, $order_id );
+	$request = Nets_Easy()->api->get_nets_easy_order( $payment_id );
 
 	if ( is_wp_error( $request ) ) {
 		$order->add_order_note(


### PR DESCRIPTION
At `init` time, any function that rely on URL related functions (e.g., is_wc_endpoint_url or is_checkout) will never be executed as the URL has not been parsed yet. This results in plugin such as Additional Checkout Fields never executing their logic since these queries would return false.

Delay until `wp` time to allow the URL be evaluate, and plugin that rely it on process their business logic.

https://app.clickup.com/t/869d8cdum