### PR TITLE
Save shipping_phone and hide field by default

### DIFF
--- a/assets/js/nets-easy-for-woocommerce.js
+++ b/assets/js/nets-easy-for-woocommerce.js
@@ -354,6 +354,23 @@ jQuery( function ( $ ) {
                 $( dibsEasyForWoocommerce.wooTerms ).prop( "checked", true )
             }
             $( "input#ship-to-different-address-checkbox" ).prop( "checked", true )
+
+            const $shippingPhone = $( "#shipping_phone" )
+            if ( $shippingPhone.length ) {
+                const spn = shippingAddress.phoneNumber
+                const phoneVal = spn ? `${ spn.prefix }${ spn.number }` : $( "#billing_phone" ).val()
+                if ( phoneVal ) {
+                    $shippingPhone.val( phoneVal )
+                }
+            }
+            const $shippingEmail = $( "#shipping_email" )
+            if ( $shippingEmail.length ) {
+                const emailVal = $( "#billing_email" ).val()
+                if ( emailVal ) {
+                    $shippingEmail.val( emailVal )
+                }
+            }
+
             dibsEasyForWoocommerce.submitOrder()
         },
         /**

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Nexi Checkout Changelog ***
+2026-05-28      - version 2.14.5
+* Fix           - Resolved a checkout validation error that could occur after upgrading to WooCommerce 10.8.0, where an empty shipping phone number caused the order to fail. The shipping phone field is now correctly populated with the value from Nexi, or the billing phone number if no shipping phone is provided.
+
 2026-05-18      - version 2.14.4
 * Fix           - Fixed an issue where a "Pay" button appeared on the order confirmation page for orders that had already been successfully paid.
 * Fix           - Added the request URL as the 2nd parameter to the 'http_headers_useragent' filter which is required for other plugins that hook onto this filter that need the URL to modify the user agent string accordingly.

--- a/classes/class-nets-easy-assets.php
+++ b/classes/class-nets-easy-assets.php
@@ -386,6 +386,8 @@ class Nets_Easy_Assets {
 				'shipping_state',
 				'shipping_country',
 				'shipping_company',
+				'shipping_phone',
+				'shipping_email',
 				'terms',
 				'account_username',
 				'account_password',

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Plugin Name:             Nexi Checkout
  * Plugin URI:              https://krokedil.se/produkt/nets-easy/
  * Description:             Extends WooCommerce. Provides a <a href="http://developer.nexigroup.com/nexi-checkout/en-EU/docs/checkout-for-woocommerce/" target="_blank">Nexi Checkout</a> payment solution for WooCommerce.
- * Version:                 2.14.4
+ * Version:                 2.14.5
  * Author:                  Krokedil
  * Author URI:              https://krokedil.se/
  * Developer:               Krokedil

--- a/dibs-easy-for-woocommerce.php
+++ b/dibs-easy-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Text Domain:             dibs-easy-for-woocommerce
  * Domain Path:             /languages
  * WC requires at least:    5.6.0
- * WC tested up to:         10.7.0
+ * WC tested up to:         10.8.1
  * Copyright:               © 2017-2026 Krokedil AB.
  * License:                 GNU General Public License v3.0
  * License URI:             http://www.gnu.org/licenses/gpl-3.0.html
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_DIBS_EASY_VERSION', '2.14.4' );
+define( 'WC_DIBS_EASY_VERSION', '2.14.5' );
 define( 'WC_DIBS__URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_DIBS_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'DIBS_API_LIVE_ENDPOINT', 'https://api.dibspayment.eu/v1/' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 Contributors: dibspayment, krokedil, NiklasHogefjord
 Tags: ecommerce, e-commerce, woocommerce, dibs, nets easy, nets, nexi
 Requires at least: 5.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 WC requires at least: 5.6.0
-WC tested up to: 10.7.0
-Stable tag: 2.14.4
+WC tested up to: 10.8.1
+Stable tag: 2.14.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -59,6 +59,9 @@ For help setting up and configuring Nexi Checkout please refer to our [documenta
 * This plugin integrates with Nexi Checkout. You need an agreement with Nets specific to the Nexi Checkout platform to use this plugin.
 
 == CHANGELOG ==
+= 2026-05-28    - version 2.14.5 =
+* Fix           - Resolved a checkout validation error that could occur after upgrading to WooCommerce 10.8.0, where an empty shipping phone number caused the order to fail. The shipping phone field is now correctly populated with the value from Nexi, or the billing phone number if no shipping phone is provided.
+
 = 2026-05-18    - version 2.14.4 =
 * Fix           - Fixed an issue where a "Pay" button appeared on the order confirmation page for orders that had already been successfully paid.
 * Fix           - Added the request URL as the 2nd parameter to the 'http_headers_useragent' filter which is required for other plugins that hook onto this filter that need the URL to modify the user agent string accordingly.


### PR DESCRIPTION
* Fix           - Resolved a checkout validation error that could occur after upgrading to WooCommerce 10.8.0, where an empty shipping phone number caused the order to fail. The shipping phone field is now correctly populated with the value from Nexi, or the billing phone number if no shipping phone is provided.

https://app.clickup.com/t/869dfa86a